### PR TITLE
Add quest system with NPC loot drops

### DIFF
--- a/commands/attack.go
+++ b/commands/attack.go
@@ -38,6 +38,42 @@ var Attack = Define(Definition{
 			if levels > 0 {
 				ctx.Player.Output <- game.Ansi(fmt.Sprintf("\r\nYou advance to level %d!", ctx.Player.Level))
 			}
+			if len(result.Loot) > 0 {
+				names := make([]string, len(result.Loot))
+				for i, item := range result.Loot {
+					names[i] = game.HighlightItemName(item.Name)
+				}
+				lootLine := fmt.Sprintf("\r\n%s drops %s.", npcName, strings.Join(names, ", "))
+				ctx.Player.Output <- game.Ansi(lootLine)
+				ctx.World.BroadcastToRoom(ctx.Player.Room, game.Ansi(fmt.Sprintf("\r\n%s leaves behind %s.", npcName, strings.Join(names, ", "))), ctx.Player)
+			}
+			if updates := ctx.World.RecordNPCKill(ctx.Player, result.NPC); len(updates) > 0 {
+				for _, update := range updates {
+					for _, prog := range update.KillProgress {
+						ctx.Player.Output <- game.Ansi(fmt.Sprintf("\r\n[Quest] %s: %s (%d/%d)",
+							game.HighlightQuestName(update.Quest.Name),
+							game.HighlightNPCName(prog.NPC),
+							prog.Current,
+							prog.Required,
+						))
+					}
+					if update.KillsCompleted {
+						turnIn := update.Quest.TurnIn
+						if strings.TrimSpace(turnIn) == "" {
+							turnIn = update.Quest.Giver
+						}
+						if turnIn != "" {
+							ctx.Player.Output <- game.Ansi(fmt.Sprintf("\r\n[Quest] %s objectives complete. Visit %s to turn in.",
+								game.HighlightQuestName(update.Quest.Name),
+								game.HighlightNPCName(turnIn),
+							))
+						} else {
+							ctx.Player.Output <- game.Ansi(fmt.Sprintf("\r\n[Quest] %s objectives complete.",
+								game.HighlightQuestName(update.Quest.Name)))
+						}
+					}
+				}
+			}
 		}
 		ctx.Player.Output <- game.Prompt(ctx.Player)
 		return false

--- a/commands/look.go
+++ b/commands/look.go
@@ -29,6 +29,25 @@ var Look = Define(Definition{
 				line = fmt.Sprintf("%s They say, \"%s\"", line, greet)
 			}
 			ctx.Player.Output <- game.Ansi(line)
+			if offered := ctx.World.QuestsByNPC(npc.Name); len(offered) > 0 {
+				if available := ctx.World.AvailableQuests(ctx.Player); len(available) > 0 {
+					eligible := make(map[string]struct{}, len(available))
+					for _, quest := range available {
+						eligible[strings.ToLower(quest.ID)] = struct{}{}
+					}
+					var names []string
+					for _, quest := range offered {
+						if _, ok := eligible[strings.ToLower(quest.ID)]; !ok {
+							continue
+						}
+						names = append(names, game.HighlightQuestName(quest.Name))
+					}
+					if len(names) > 0 {
+						ctx.Player.Output <- game.Ansi(fmt.Sprintf("\r\nThey seem ready to offer: %s", strings.Join(names, ", ")))
+						ctx.Player.Output <- game.Ansi("\r\nUse 'quests accept <id>' to begin.")
+					}
+				}
+			}
 			return false
 		}
 		if item, found := ctx.World.FindRoomItem(ctx.Player.Room, target); found {

--- a/commands/quests.go
+++ b/commands/quests.go
@@ -1,0 +1,149 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"LumenClay/internal/game"
+)
+
+var Quests = Define(Definition{
+	Name:        "quests",
+	Aliases:     []string{"quest"},
+	Usage:       "quests [available|active|accept <id>|turnin <id>]",
+	Description: "review active quests or interact with quest givers",
+}, func(ctx *Context) bool {
+	width, _ := ctx.Player.WindowSize()
+	parts := strings.Fields(ctx.Arg)
+	if len(parts) == 0 {
+		return showActiveQuests(ctx, width)
+	}
+
+	sub := strings.ToLower(parts[0])
+	switch sub {
+	case "active", "log":
+		return showActiveQuests(ctx, width)
+	case "available":
+		return showAvailableQuests(ctx, width)
+	case "accept":
+		if len(parts) < 2 {
+			ctx.Player.Output <- game.Ansi(game.Style("\r\nUsage: quests accept <id>", game.AnsiYellow))
+			return false
+		}
+		questID := strings.ToLower(parts[1])
+		quest, err := ctx.World.AcceptQuest(ctx.Player, questID)
+		if err != nil {
+			ctx.Player.Output <- game.Ansi(game.Style("\r\n"+err.Error(), game.AnsiYellow))
+			return false
+		}
+		ctx.Player.Output <- game.Ansi(fmt.Sprintf("\r\nYou accept %s.", game.HighlightQuestName(quest.Name)))
+		if desc := strings.TrimSpace(quest.Description); desc != "" {
+			ctx.Player.Output <- game.Ansi("\r\n" + game.WrapText(desc, width))
+		}
+		return false
+	case "turnin", "complete":
+		if len(parts) < 2 {
+			ctx.Player.Output <- game.Ansi(game.Style("\r\nUsage: quests turnin <id>", game.AnsiYellow))
+			return false
+		}
+		questID := strings.ToLower(parts[1])
+		result, err := ctx.World.CompleteQuest(ctx.Player, questID)
+		if err != nil {
+			ctx.Player.Output <- game.Ansi(game.Style("\r\n"+err.Error(), game.AnsiYellow))
+			return false
+		}
+		ctx.Player.Output <- game.Ansi(fmt.Sprintf("\r\nYou complete %s!", game.HighlightQuestName(result.Quest.Name)))
+		if strings.TrimSpace(result.CompletionMsg) != "" {
+			ctx.Player.Output <- game.Ansi("\r\n" + game.WrapText(result.CompletionMsg, width))
+		}
+		if result.RewardXP > 0 {
+			ctx.Player.Output <- game.Ansi(fmt.Sprintf("\r\nYou gain %d experience.", result.RewardXP))
+			if result.LevelsGained > 0 {
+				ctx.Player.Output <- game.Ansi(fmt.Sprintf("\r\nYou advance to level %d!", ctx.Player.Level))
+			}
+		}
+		if len(result.RewardItems) > 0 {
+			names := make([]string, len(result.RewardItems))
+			for i, item := range result.RewardItems {
+				names[i] = game.HighlightItemName(item.Name)
+			}
+			ctx.Player.Output <- game.Ansi(fmt.Sprintf("\r\nRewards: %s", strings.Join(names, ", ")))
+		}
+		return false
+	default:
+		ctx.Player.Output <- game.Ansi(game.Style("\r\nUnrecognised quests subcommand.", game.AnsiYellow))
+		return false
+	}
+})
+
+func showActiveQuests(ctx *Context, width int) bool {
+	snapshots := ctx.World.SnapshotQuestLog(ctx.Player)
+	if len(snapshots) == 0 {
+		ctx.Player.Output <- game.Ansi("\r\nYou have no active quests.")
+		return false
+	}
+	inventory := ctx.World.PlayerInventory(ctx.Player)
+	itemCounts := make(map[string]int)
+	for _, item := range inventory {
+		itemCounts[strings.ToLower(item.Name)]++
+	}
+	for _, snap := range snapshots {
+		status := "in progress"
+		if snap.Completed {
+			status = "completed"
+		}
+		header := fmt.Sprintf("\r\n%s (%s)", game.HighlightQuestName(snap.Quest.Name), status)
+		ctx.Player.Output <- game.Ansi(header)
+		if desc := strings.TrimSpace(snap.Quest.Description); desc != "" {
+			ctx.Player.Output <- game.Ansi("\r\n  " + game.WrapText(desc, width))
+		}
+		for _, prog := range snap.KillProgress {
+			ctx.Player.Output <- game.Ansi(fmt.Sprintf("\r\n  - Defeat %s (%d/%d)",
+				game.HighlightNPCName(prog.NPC),
+				prog.Current,
+				prog.Required,
+			))
+		}
+		for _, req := range snap.Quest.RequiredItems {
+			have := itemCounts[strings.ToLower(req.Item)]
+			ctx.Player.Output <- game.Ansi(fmt.Sprintf("\r\n  - Deliver %s (%d/%d)",
+				game.HighlightItemName(req.Item),
+				have,
+				req.Count,
+			))
+		}
+	}
+	return false
+}
+
+func showAvailableQuests(ctx *Context, width int) bool {
+	quests := ctx.World.AvailableQuests(ctx.Player)
+	if len(quests) == 0 {
+		ctx.Player.Output <- game.Ansi("\r\nNo quests are available here.")
+		return false
+	}
+	for _, quest := range quests {
+		ctx.Player.Output <- game.Ansi(fmt.Sprintf("\r\n[%s] %s", strings.ToLower(quest.ID), game.HighlightQuestName(quest.Name)))
+		if desc := strings.TrimSpace(quest.Description); desc != "" {
+			ctx.Player.Output <- game.Ansi("\r\n  " + game.WrapText(desc, width))
+		}
+		if len(quest.RequiredKills) > 0 {
+			for _, req := range quest.RequiredKills {
+				ctx.Player.Output <- game.Ansi(fmt.Sprintf("\r\n  - Defeat %s (%d)",
+					game.HighlightNPCName(req.NPC),
+					req.Count,
+				))
+			}
+		}
+		if len(quest.RequiredItems) > 0 {
+			for _, req := range quest.RequiredItems {
+				ctx.Player.Output <- game.Ansi(fmt.Sprintf("\r\n  - Deliver %s (%d)",
+					game.HighlightItemName(req.Item),
+					req.Count,
+				))
+			}
+		}
+		ctx.Player.Output <- game.Ansi("\r\n")
+	}
+	return false
+}

--- a/data/areas/start.json
+++ b/data/areas/start.json
@@ -78,6 +78,21 @@
           "name": "Resonant Ladle",
           "description": "A heavy ladle whose bowl traps a sphere of luminescence; when poured, it paints temporary sigils across the pool's surface."
         }
+      ],
+      "npcs": [
+        {
+          "name": "Ember Warden",
+          "auto_greet": "The kiln-mask of the warden flares with warning embers as it measures your intent.",
+          "level": 2,
+          "health": 55,
+          "max_health": 55,
+          "loot": [
+            {
+              "name": "Resonant Core",
+              "description": "A fist-sized crystal humming with the reservoir's tempered light."
+            }
+          ]
+        }
       ]
     },
     {

--- a/data/quests.json
+++ b/data/quests.json
@@ -1,0 +1,31 @@
+{
+  "quests": [
+    {
+      "id": "stoke_reservoir",
+      "name": "Stoke the Reservoir",
+      "description": "Glazecaller Ilyss fears the ember warden beneath the atrium will overheat the lumen channels. Defeat the construct in the reservoir and return with its resonant core to restore balance.",
+      "giver": "Glazecaller Ilyss",
+      "turn_in": "Glazecaller Ilyss",
+      "required_kills": [
+        {
+          "npc": "Ember Warden",
+          "count": 1
+        }
+      ],
+      "required_items": [
+        {
+          "item": "Resonant Core",
+          "count": 1
+        }
+      ],
+      "reward_xp": 75,
+      "reward_items": [
+        {
+          "name": "Ilyss's Ember Sigil",
+          "description": "A palm-sized sigil that glows warmly, marking you as a steward of the reservoir."
+        }
+      ],
+      "completion_message": "Ilyss seals the core within a channeling prism and nods approvingly. \"The reservoir hums in balance once more.\""
+    }
+  ]
+}

--- a/internal/game/ansi.go
+++ b/internal/game/ansi.go
@@ -50,6 +50,11 @@ func HighlightItemName(name string) string {
 	return Style(name, AnsiBold, AnsiYellow)
 }
 
+// HighlightQuestName formats quest titles consistently.
+func HighlightQuestName(name string) string {
+	return Style(name, AnsiBold, AnsiBlue)
+}
+
 // Trim normalises a telnet input line.
 func Trim(s string) string {
 	cleaned := sanitizeInput(s)

--- a/internal/game/player.go
+++ b/internal/game/player.go
@@ -31,6 +31,7 @@ type Player struct {
 	channelHistory   map[Channel][]ChannelLogEntry
 	channelHistoryMu sync.Mutex
 	MutedChannels    map[Channel]bool
+	QuestLog         map[string]*QuestProgress
 }
 
 // PlayerProfile captures persistent player state and preferences.

--- a/internal/game/quests.go
+++ b/internal/game/quests.go
@@ -1,0 +1,547 @@
+package game
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const questsFileName = "quests.json"
+
+// Quest describes a structured task offered by NPCs.
+type Quest struct {
+	ID                string                 `json:"id"`
+	Name              string                 `json:"name"`
+	Description       string                 `json:"description"`
+	Giver             string                 `json:"giver"`
+	TurnIn            string                 `json:"turn_in,omitempty"`
+	RequiredKills     []QuestKillRequirement `json:"required_kills,omitempty"`
+	RequiredItems     []QuestItemRequirement `json:"required_items,omitempty"`
+	RewardXP          int                    `json:"reward_xp,omitempty"`
+	RewardItems       []Item                 `json:"reward_items,omitempty"`
+	CompletionMessage string                 `json:"completion_message,omitempty"`
+}
+
+// QuestKillRequirement tracks how many times a specific NPC must be defeated.
+type QuestKillRequirement struct {
+	NPC   string `json:"npc"`
+	Count int    `json:"count,omitempty"`
+}
+
+// QuestItemRequirement lists an item the player must deliver.
+type QuestItemRequirement struct {
+	Item  string `json:"item"`
+	Count int    `json:"count,omitempty"`
+}
+
+type questFile struct {
+	Quests []Quest `json:"quests"`
+}
+
+func loadQuestData(areasPath string) (map[string]*Quest, error) {
+	if strings.TrimSpace(areasPath) == "" {
+		return nil, nil
+	}
+	dir := filepath.Dir(areasPath)
+	path := filepath.Join(dir, questsFileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var parsed questFile
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return nil, fmt.Errorf("parse quests: %w", err)
+	}
+	if len(parsed.Quests) == 0 {
+		return nil, nil
+	}
+	quests := make(map[string]*Quest, len(parsed.Quests))
+	for i := range parsed.Quests {
+		quest := &parsed.Quests[i]
+		normalizeQuest(quest)
+		if quest.ID == "" || quest.Name == "" {
+			continue
+		}
+		quests[strings.ToLower(quest.ID)] = quest
+	}
+	if len(quests) == 0 {
+		return nil, nil
+	}
+	return quests, nil
+}
+
+func normalizeQuest(q *Quest) {
+	if q == nil {
+		return
+	}
+	q.ID = strings.TrimSpace(q.ID)
+	q.Name = strings.TrimSpace(q.Name)
+	q.Description = strings.TrimSpace(q.Description)
+	q.Giver = strings.TrimSpace(q.Giver)
+	q.TurnIn = strings.TrimSpace(q.TurnIn)
+	if q.TurnIn == "" {
+		q.TurnIn = q.Giver
+	}
+	for i := range q.RequiredKills {
+		q.RequiredKills[i].NPC = strings.TrimSpace(q.RequiredKills[i].NPC)
+		if q.RequiredKills[i].Count <= 0 {
+			q.RequiredKills[i].Count = 1
+		}
+	}
+	for i := range q.RequiredItems {
+		q.RequiredItems[i].Item = strings.TrimSpace(q.RequiredItems[i].Item)
+		if q.RequiredItems[i].Count <= 0 {
+			q.RequiredItems[i].Count = 1
+		}
+	}
+	for i := range q.RewardItems {
+		q.RewardItems[i].Name = strings.TrimSpace(q.RewardItems[i].Name)
+		q.RewardItems[i].Description = strings.TrimSpace(q.RewardItems[i].Description)
+	}
+	if q.RewardXP < 0 {
+		q.RewardXP = 0
+	}
+	q.CompletionMessage = strings.TrimSpace(q.CompletionMessage)
+}
+
+func indexQuestsByNPC(quests map[string]*Quest) map[string][]*Quest {
+	if len(quests) == 0 {
+		return nil
+	}
+	byNPC := make(map[string][]*Quest)
+	for _, quest := range quests {
+		npc := strings.ToLower(strings.TrimSpace(quest.Giver))
+		if npc == "" {
+			continue
+		}
+		byNPC[npc] = append(byNPC[npc], quest)
+	}
+	for _, list := range byNPC {
+		sort.SliceStable(list, func(i, j int) bool {
+			return list[i].Name < list[j].Name
+		})
+	}
+	return byNPC
+}
+
+// QuestProgress captures in-progress quest objectives.
+type QuestProgress struct {
+	QuestID     string
+	AcceptedAt  time.Time
+	CompletedAt time.Time
+	Completed   bool
+	KillCounts  map[string]int
+}
+
+func newQuestProgress(quest *Quest) *QuestProgress {
+	progress := &QuestProgress{
+		QuestID:    strings.ToLower(quest.ID),
+		AcceptedAt: time.Now().UTC(),
+		KillCounts: make(map[string]int, len(quest.RequiredKills)),
+	}
+	for _, req := range quest.RequiredKills {
+		key := strings.ToLower(req.NPC)
+		if key == "" {
+			continue
+		}
+		if _, exists := progress.KillCounts[key]; !exists {
+			progress.KillCounts[key] = 0
+		}
+	}
+	return progress
+}
+
+func (p *QuestProgress) incrementKill(quest *Quest, npcName string) ([]QuestKillProgress, bool) {
+	if p == nil || quest == nil {
+		return nil, false
+	}
+	if p.Completed {
+		return nil, false
+	}
+	normalized := strings.ToLower(strings.TrimSpace(npcName))
+	if normalized == "" {
+		return nil, false
+	}
+	updated := false
+	updates := make([]QuestKillProgress, 0, len(quest.RequiredKills))
+	for _, req := range quest.RequiredKills {
+		key := strings.ToLower(req.NPC)
+		if key == "" || key != normalized {
+			continue
+		}
+		have := p.KillCounts[key]
+		need := req.Count
+		if need <= 0 {
+			need = 1
+		}
+		if have >= need {
+			updates = append(updates, QuestKillProgress{NPC: req.NPC, Current: have, Required: need})
+			continue
+		}
+		have++
+		if have > need {
+			have = need
+		}
+		p.KillCounts[key] = have
+		updates = append(updates, QuestKillProgress{NPC: req.NPC, Current: have, Required: need})
+		updated = true
+	}
+	return updates, updated
+}
+
+func (p *QuestProgress) killsComplete(quest *Quest) bool {
+	if p == nil || quest == nil {
+		return false
+	}
+	for _, req := range quest.RequiredKills {
+		key := strings.ToLower(req.NPC)
+		if key == "" {
+			continue
+		}
+		need := req.Count
+		if need <= 0 {
+			need = 1
+		}
+		if p.KillCounts[key] < need {
+			return false
+		}
+	}
+	return true
+}
+
+// QuestKillProgress summarises a kill objective.
+type QuestKillProgress struct {
+	NPC      string
+	Current  int
+	Required int
+}
+
+// QuestProgressSnapshot captures quest progress for presentation.
+type QuestProgressSnapshot struct {
+	Quest        *Quest
+	Completed    bool
+	AcceptedAt   time.Time
+	CompletedAt  time.Time
+	KillProgress []QuestKillProgress
+}
+
+// QuestProgressUpdate reports incremental changes after quest progress changes.
+type QuestProgressUpdate struct {
+	Quest          *Quest
+	KillProgress   []QuestKillProgress
+	KillsCompleted bool
+}
+
+// QuestCompletionResult describes the rewards granted for finishing a quest.
+type QuestCompletionResult struct {
+	Quest         *Quest
+	RewardItems   []Item
+	RewardXP      int
+	LevelsGained  int
+	CompletionMsg string
+}
+
+// QuestsByNPC lists quests offered by the specified NPC.
+func (w *World) QuestsByNPC(name string) []*Quest {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return nil
+	}
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	quests := w.questsByNPC[strings.ToLower(trimmed)]
+	if len(quests) == 0 {
+		return nil
+	}
+	out := make([]*Quest, len(quests))
+	copy(out, quests)
+	return out
+}
+
+// AvailableQuests returns quests that the player can accept in their current room.
+func (w *World) AvailableQuests(p *Player) []*Quest {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	stored, ok := w.players[p.Name]
+	if !ok || stored != p || !p.Alive {
+		return nil
+	}
+	room, ok := w.rooms[p.Room]
+	if !ok {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var available []*Quest
+	for _, npc := range room.NPCs {
+		key := strings.ToLower(strings.TrimSpace(npc.Name))
+		if key == "" {
+			continue
+		}
+		quests := w.questsByNPC[key]
+		for _, quest := range quests {
+			if quest == nil {
+				continue
+			}
+			id := strings.ToLower(quest.ID)
+			if _, exists := seen[id]; exists {
+				continue
+			}
+			if _, active := p.QuestLog[id]; active {
+				continue
+			}
+			available = append(available, quest)
+			seen[id] = struct{}{}
+		}
+	}
+	if len(available) == 0 {
+		return nil
+	}
+	sort.SliceStable(available, func(i, j int) bool {
+		return available[i].Name < available[j].Name
+	})
+	return available
+}
+
+// AcceptQuest marks a quest as active for the player.
+func (w *World) AcceptQuest(p *Player, questID string) (*Quest, error) {
+	trimmed := strings.ToLower(strings.TrimSpace(questID))
+	if trimmed == "" {
+		return nil, fmt.Errorf("quest id must not be empty")
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	stored, ok := w.players[p.Name]
+	if !ok || stored != p || !p.Alive {
+		return nil, fmt.Errorf("%s is not online", p.Name)
+	}
+	quest, ok := w.quests[trimmed]
+	if !ok {
+		return nil, fmt.Errorf("no such quest")
+	}
+	room, ok := w.rooms[p.Room]
+	if !ok {
+		return nil, fmt.Errorf("unknown room: %s", p.Room)
+	}
+	giver := strings.ToLower(quest.Giver)
+	present := false
+	for _, npc := range room.NPCs {
+		if strings.EqualFold(npc.Name, quest.Giver) {
+			present = true
+			break
+		}
+		if giver != "" && strings.ToLower(strings.TrimSpace(npc.Name)) == giver {
+			present = true
+			break
+		}
+	}
+	if !present {
+		return nil, fmt.Errorf("%s is not here", quest.Giver)
+	}
+	if p.QuestLog == nil {
+		p.QuestLog = make(map[string]*QuestProgress)
+	}
+	if progress, exists := p.QuestLog[trimmed]; exists {
+		if progress.Completed {
+			return nil, fmt.Errorf("you have already completed that quest")
+		}
+		return nil, fmt.Errorf("you are already on that quest")
+	}
+	p.QuestLog[trimmed] = newQuestProgress(quest)
+	return quest, nil
+}
+
+// SnapshotQuestLog returns a copy of the player's quest progress.
+func (w *World) SnapshotQuestLog(p *Player) []QuestProgressSnapshot {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	stored, ok := w.players[p.Name]
+	if !ok || stored != p || len(p.QuestLog) == 0 {
+		return nil
+	}
+	snapshots := make([]QuestProgressSnapshot, 0, len(p.QuestLog))
+	for id, progress := range p.QuestLog {
+		quest, exists := w.quests[id]
+		if !exists || quest == nil {
+			continue
+		}
+		snapshot := QuestProgressSnapshot{
+			Quest:       quest,
+			Completed:   progress.Completed,
+			AcceptedAt:  progress.AcceptedAt,
+			CompletedAt: progress.CompletedAt,
+		}
+		if len(quest.RequiredKills) > 0 {
+			kills := make([]QuestKillProgress, len(quest.RequiredKills))
+			for i, req := range quest.RequiredKills {
+				key := strings.ToLower(req.NPC)
+				kills[i] = QuestKillProgress{
+					NPC:      req.NPC,
+					Current:  progress.KillCounts[key],
+					Required: req.Count,
+				}
+				if kills[i].Required <= 0 {
+					kills[i].Required = 1
+				}
+			}
+			snapshot.KillProgress = kills
+		}
+		snapshots = append(snapshots, snapshot)
+	}
+	if len(snapshots) == 0 {
+		return nil
+	}
+	sort.SliceStable(snapshots, func(i, j int) bool {
+		return snapshots[i].Quest.Name < snapshots[j].Quest.Name
+	})
+	return snapshots
+}
+
+// RecordNPCKill updates quest progress after an NPC is defeated.
+func (w *World) RecordNPCKill(p *Player, npc NPC) []QuestProgressUpdate {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	stored, ok := w.players[p.Name]
+	if !ok || stored != p || len(p.QuestLog) == 0 {
+		return nil
+	}
+	normalized := strings.ToLower(strings.TrimSpace(npc.Name))
+	if normalized == "" {
+		return nil
+	}
+	updates := make([]QuestProgressUpdate, 0, len(p.QuestLog))
+	for id, progress := range p.QuestLog {
+		if progress.Completed {
+			continue
+		}
+		quest := w.quests[id]
+		if quest == nil {
+			continue
+		}
+		killUpdates, changed := progress.incrementKill(quest, npc.Name)
+		if !changed || len(killUpdates) == 0 {
+			continue
+		}
+		updates = append(updates, QuestProgressUpdate{
+			Quest:          quest,
+			KillProgress:   killUpdates,
+			KillsCompleted: progress.killsComplete(quest),
+		})
+	}
+	if len(updates) == 0 {
+		return nil
+	}
+	return updates
+}
+
+// CompleteQuest checks requirements and awards quest rewards.
+func (w *World) CompleteQuest(p *Player, questID string) (*QuestCompletionResult, error) {
+	trimmed := strings.ToLower(strings.TrimSpace(questID))
+	if trimmed == "" {
+		return nil, fmt.Errorf("quest id must not be empty")
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	stored, ok := w.players[p.Name]
+	if !ok || stored != p || !p.Alive {
+		return nil, fmt.Errorf("%s is not online", p.Name)
+	}
+	quest, ok := w.quests[trimmed]
+	if !ok {
+		return nil, fmt.Errorf("no such quest")
+	}
+	progress, ok := p.QuestLog[trimmed]
+	if !ok {
+		return nil, fmt.Errorf("you have not accepted that quest")
+	}
+	if progress.Completed {
+		return nil, fmt.Errorf("you have already completed that quest")
+	}
+	room, ok := w.rooms[p.Room]
+	if !ok {
+		return nil, fmt.Errorf("unknown room: %s", p.Room)
+	}
+	turnIn := quest.TurnIn
+	if turnIn == "" {
+		turnIn = quest.Giver
+	}
+	present := false
+	for _, npc := range room.NPCs {
+		if strings.EqualFold(npc.Name, turnIn) {
+			present = true
+			break
+		}
+	}
+	if !present {
+		return nil, fmt.Errorf("%s is not here", turnIn)
+	}
+	if !progress.killsComplete(quest) {
+		return nil, fmt.Errorf("you have not completed the objectives")
+	}
+	if len(quest.RequiredItems) > 0 {
+		inventoryCounts := make(map[string]int)
+		for _, item := range p.Inventory {
+			inventoryCounts[strings.ToLower(item.Name)]++
+		}
+		for _, req := range quest.RequiredItems {
+			key := strings.ToLower(req.Item)
+			if key == "" {
+				continue
+			}
+			need := req.Count
+			if need <= 0 {
+				need = 1
+			}
+			if inventoryCounts[key] < need {
+				return nil, fmt.Errorf("you still need %d %s", need, req.Item)
+			}
+		}
+		// Remove the required items.
+		for _, req := range quest.RequiredItems {
+			key := strings.ToLower(req.Item)
+			if key == "" {
+				continue
+			}
+			remaining := req.Count
+			if remaining <= 0 {
+				remaining = 1
+			}
+			filtered := p.Inventory[:0]
+			for _, item := range p.Inventory {
+				if remaining > 0 && strings.EqualFold(item.Name, req.Item) {
+					remaining--
+					continue
+				}
+				filtered = append(filtered, item)
+			}
+			p.Inventory = append([]Item(nil), filtered...)
+		}
+	}
+	rewardItems := make([]Item, len(quest.RewardItems))
+	copy(rewardItems, quest.RewardItems)
+	if len(rewardItems) > 0 {
+		p.Inventory = append(p.Inventory, rewardItems...)
+	}
+	rewardXP := quest.RewardXP
+	levels := 0
+	if rewardXP > 0 {
+		levels = p.GainExperience(rewardXP)
+	}
+	progress.Completed = true
+	progress.CompletedAt = time.Now().UTC()
+	result := &QuestCompletionResult{
+		Quest:         quest,
+		RewardItems:   rewardItems,
+		RewardXP:      rewardXP,
+		LevelsGained:  levels,
+		CompletionMsg: quest.CompletionMessage,
+	}
+	return result, nil
+}

--- a/internal/game/quests_test.go
+++ b/internal/game/quests_test.go
@@ -1,0 +1,97 @@
+package game
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestQuestLifecycle(t *testing.T) {
+	roomID := RoomID("start")
+	quest := &Quest{
+		ID:          "ember_trial",
+		Name:        "Ember Trial",
+		Description: "Defeat the guardian and return with its core.",
+		Giver:       "Guide",
+		TurnIn:      "Guide",
+		RequiredKills: []QuestKillRequirement{
+			{NPC: "Warden", Count: 1},
+		},
+		RequiredItems: []QuestItemRequirement{
+			{Item: "Core", Count: 1},
+		},
+		RewardXP:          100,
+		RewardItems:       []Item{{Name: "Shard"}},
+		CompletionMessage: "The guardian rests once more.",
+	}
+	normalizeQuest(quest)
+
+	world := NewWorldWithRooms(map[RoomID]*Room{
+		roomID: {
+			ID:    roomID,
+			NPCs:  []NPC{{Name: "Guide"}},
+			Items: []Item{},
+		},
+	})
+	world.quests = map[string]*Quest{"ember_trial": quest}
+	world.questsByNPC = indexQuestsByNPC(world.quests)
+
+	player := &Player{Name: "Hero", Room: roomID, Alive: true}
+	world.AddPlayerForTest(player)
+
+	if available := world.AvailableQuests(player); len(available) != 1 || available[0].ID != quest.ID {
+		t.Fatalf("expected quest to be available, got %+v", available)
+	}
+
+	if _, err := world.AcceptQuest(player, "ember_trial"); err != nil {
+		t.Fatalf("AcceptQuest returned error: %v", err)
+	}
+
+	if available := world.AvailableQuests(player); len(available) != 0 {
+		t.Fatalf("expected no quests after acceptance, got %+v", available)
+	}
+
+	updates := world.RecordNPCKill(player, NPC{Name: "Warden"})
+	if len(updates) != 1 {
+		t.Fatalf("expected kill update, got %+v", updates)
+	}
+	if updates[0].KillProgress[0].Current != 1 {
+		t.Fatalf("expected kill progress 1, got %+v", updates[0].KillProgress)
+	}
+
+	if _, err := world.CompleteQuest(player, "ember_trial"); err == nil || !strings.Contains(err.Error(), "need") {
+		t.Fatalf("expected missing item error, got %v", err)
+	}
+
+	player.Inventory = append(player.Inventory, Item{Name: "Core"})
+	result, err := world.CompleteQuest(player, "ember_trial")
+	if err != nil {
+		t.Fatalf("CompleteQuest returned error: %v", err)
+	}
+	if !player.QuestLog["ember_trial"].Completed {
+		t.Fatalf("quest progress not marked complete")
+	}
+	if result.RewardXP != quest.RewardXP {
+		t.Fatalf("reward xp = %d, want %d", result.RewardXP, quest.RewardXP)
+	}
+	if result.LevelsGained == 0 {
+		t.Fatalf("expected level gain from quest reward")
+	}
+	if len(result.RewardItems) != 1 || result.RewardItems[0].Name != "Shard" {
+		t.Fatalf("unexpected reward items: %+v", result.RewardItems)
+	}
+	if strings.TrimSpace(result.CompletionMsg) == "" {
+		t.Fatalf("expected completion message")
+	}
+	foundShard := false
+	for _, item := range player.Inventory {
+		if strings.EqualFold(item.Name, "Core") {
+			t.Fatalf("expected core to be removed from inventory")
+		}
+		if item.Name == "Shard" {
+			foundShard = true
+		}
+	}
+	if !foundShard {
+		t.Fatalf("expected reward shard in inventory, got %+v", player.Inventory)
+	}
+}

--- a/internal/game/world_test.go
+++ b/internal/game/world_test.go
@@ -127,6 +127,36 @@ func TestWorldTakeItemPartialAmbiguous(t *testing.T) {
 	}
 }
 
+func TestApplyDamageToNPCLootDrops(t *testing.T) {
+	roomID := RoomID("arena")
+	loot := Item{Name: "Glittering Gem"}
+	world := &World{
+		rooms: map[RoomID]*Room{
+			roomID: {
+				ID:   roomID,
+				NPCs: []NPC{{Name: "Loot Goblin", Health: 10, MaxHealth: 10, Loot: []Item{loot}}},
+			},
+		},
+	}
+
+	result, err := world.ApplyDamageToNPC(roomID, "goblin", 20)
+	if err != nil {
+		t.Fatalf("ApplyDamageToNPC returned error: %v", err)
+	}
+	if !result.Defeated {
+		t.Fatalf("expected NPC to be defeated")
+	}
+	if len(result.Loot) != 1 || result.Loot[0].Name != loot.Name {
+		t.Fatalf("expected loot in result, got %+v", result.Loot)
+	}
+	if len(world.rooms[roomID].Items) != 1 || world.rooms[roomID].Items[0].Name != loot.Name {
+		t.Fatalf("expected loot dropped into room, got %+v", world.rooms[roomID].Items)
+	}
+	if len(world.rooms[roomID].NPCs) != 0 {
+		t.Fatalf("expected NPC removed after defeat")
+	}
+}
+
 func TestCloneRoomPopulationUnknownSource(t *testing.T) {
 	targetID := RoomID("target")
 	world := &World{


### PR DESCRIPTION
## Summary
- add quest data model, loader, and world helpers to track quest availability, kill progress, and completion rewards
- extend combat to drop NPC loot, report quest updates, and surface offerings from quest-giving NPCs via the new quests command
- seed the starting area with an Ember Warden quest and cover the new systems with unit tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68d5ef238f48832aad85da220a852970