### PR TITLE
Expand areas with new rooms, items, and NPCs

### DIFF
--- a/data/areas/garden.json
+++ b/data/areas/garden.json
@@ -4,12 +4,14 @@
     {
       "id": "garden",
       "title": "Night Garden",
-      "description": "Bioluminescent vines twine overhead. Footsteps hush on moss.",
+      "description": "Bioluminescent vines twine overhead and sway in time with unseen crickets. Footsteps hush on mossy paths that glow brighter beneath kind intentions. Perfumed mists drift between sculpted hedges, each whispering directions in floral scents toward the districts beyond.",
       "exits": {
         "d": "catacomb_nursery",
         "e": "glasshouse",
         "n": "start",
+        "ne": "chorus_arbor",
         "s": "moonpool",
+        "sw": "glowroot_labyrinth",
         "w": "root_caves"
       },
       "items": [
@@ -20,81 +22,417 @@
         {
           "name": "Vial of Dew",
           "description": "The droplets chime like tiny bells whenever danger nears."
+        },
+        {
+          "name": "Fragrance Compass",
+          "description": "A ceramic bloom that turns toward whichever scent currently guides the garden's guardians."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Garden Docent Syra",
+          "auto_greet": "Follow the scent of moon-mint if you wish to dream true tonight."
+        }
+      ]
+    },
+    {
+      "id": "chorus_arbor",
+      "title": "Chorus Arbor",
+      "description": "Branching trellises weave together into a vaulted chamber alive with the harmonized buzz of pollinators. Each vine bears clay chimes tuned to bird calls, creating a symphony that shepherds the nocturnal blooms open.",
+      "exits": {
+        "e": "orchidarium",
+        "n": "pollinator_sanctum",
+        "s": "garden"
+      },
+      "items": [
+        {
+          "name": "Harmony Leaf",
+          "description": "Pressing the leaf to your ear lets you hear the chorus guiding migrating birds overhead."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Choirmistress Lalei",
+          "auto_greet": "Join the refrain and the arbor will braid a path where you need it most."
+        }
+      ]
+    },
+    {
+      "id": "pollinator_sanctum",
+      "title": "Pollinator Sanctum",
+      "description": "Glass hives suspended in the air revolve slowly, each home to luminous bees that sketch sigils in pollen. Nectar pools shimmer in recessed basins, projecting memories of every garden tended this season.",
+      "exits": {
+        "e": "dewfall_veranda",
+        "s": "chorus_arbor",
+        "w": "orchidarium"
+      },
+      "items": [
+        {
+          "name": "Pollen Censer",
+          "description": "A delicate censer that releases a calming haze encouraging even the shyest flora to bloom."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Keeper Daxil",
+          "auto_greet": "Mind the bees—they are writing tomorrow's harvest in the air."
+        }
+      ]
+    },
+    {
+      "id": "orchidarium",
+      "title": "Shifting Orchidarium",
+      "description": "Panels of translucent clay slide silently to rearrange terraces of orchids, ensuring each blossom shares precisely the right light. Dew-beads drift between petals, carrying whispered gossip from distant corners of the garden.",
+      "exits": {
+        "n": "glasshouse",
+        "e": "pollinator_sanctum",
+        "s": "glimmer_field",
+        "w": "chorus_arbor"
+      },
+      "items": [
+        {
+          "name": "Bloom Tuning Fork",
+          "description": "Strike the fork and an orchid reshapes itself into the bloom pictured in your mind."
         }
       ]
     },
     {
       "id": "glasshouse",
       "title": "Singing Glasshouse",
-      "description": "Condensation beads chime against crystal panes, watering rows of obedient aurora-flowers.",
+      "description": "Condensation beads chime against crystal panes, watering rows of obedient aurora-flowers. Heat and chill spiral through carefully tuned vents, coaxing seedlings to glow in hues matched to the constellations above.",
       "exits": {
         "e": "rain_maker",
         "n": "lantern_row",
+        "s": "orchidarium",
         "w": "garden"
-      }
+      },
+      "items": [
+        {
+          "name": "Glimmer Shears",
+          "description": "Their blades part light without harming petals, perfect for shaping luminous blooms."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Glasswright Fen",
+          "auto_greet": "Mind the panes—each one remembers the constellation that birthed it."
+        }
+      ]
     },
     {
       "id": "rain_maker",
       "title": "Rain Maker's Platform",
-      "description": "A lattice of drums summons gentle rainclouds that politely take turns watering the beds below.",
+      "description": "A lattice of drums summons gentle rainclouds that politely take turns watering the beds below. Weather scripts carved into the railings respond to touch, altering humidity with a flourish of fingers.",
       "exits": {
+        "e": "glimmer_field",
+        "s": "dewfall_veranda",
+        "se": "mistway",
         "w": "glasshouse"
-      }
+      },
+      "items": [
+        {
+          "name": "Weather Mallet",
+          "description": "Each strike calls a different style of rainfall, from tinkling drizzle to thundering downpour."
+        }
+      ]
     },
     {
-      "id": "moonpool",
-      "title": "Moonpool Court",
-      "description": "Silver water mirrors twin moons that wink whenever a wish sounds sincere enough.",
+      "id": "dewfall_veranda",
+      "title": "Dewfall Veranda",
+      "description": "A suspended veranda catches the constant dew, letting it drip in precise rhythms into clay troughs of herbs. Bioluminescent ivy trails overhead, pulsing brighter when newcomers arrive.",
       "exits": {
-        "e": "mistway",
-        "n": "garden",
-        "s": "tidal_library"
-      }
+        "n": "rain_maker",
+        "e": "glimmer_field",
+        "s": "tideward_lookout",
+        "w": "pollinator_sanctum"
+      },
+      "items": [
+        {
+          "name": "Herbal Ledger",
+          "description": "The ledger lists which herbs bloom each hour and rearranges itself to suit the reader's needs."
+        }
+      ]
+    },
+    {
+      "id": "glimmer_field",
+      "title": "Glimmer Field",
+      "description": "Fireflies orbit waist-high topiaries, forming temporary constellations that guide travelers toward the marsh. The ground is springy and echo-free, perfect for private conversations carried on the breeze.",
+      "exits": {
+        "n": "orchidarium",
+        "ne": "mistway",
+        "nw": "rain_maker",
+        "s": "tideward_lookout",
+        "w": "dewfall_veranda"
+      },
+      "items": [
+        {
+          "name": "Firefly Lantern",
+          "description": "Unstopper the lantern to release friendly fireflies that map a safe perimeter before returning."
+        }
+      ]
+    },
+    {
+      "id": "tideward_lookout",
+      "title": "Tideward Lookout",
+      "description": "An open bluff overlooks the bioluminescent coast. Clay telescopes track wave heights, chiming when the tide brings news from distant harbors.",
+      "exits": {
+        "e": "serpent_bridge",
+        "n": "mistway",
+        "nw": "glimmer_field",
+        "s": "reef_gate"
+      },
+      "items": [
+        {
+          "name": "Tideglass",
+          "description": "A palm-sized globe that traps a momentary image of the shoreline to share with inland friends."
+        }
+      ]
     },
     {
       "id": "mistway",
       "title": "Mistway",
-      "description": "Cool fog drifts from stone arch to stone arch, carving ephemeral doorways toward the coast.",
+      "description": "Cool fog drifts from stone arch to stone arch, carving ephemeral doorways toward the coast. Every few breaths the mist parts to reveal glimpses of other travelers walking parallel paths.",
       "exits": {
         "e": "serpent_bridge",
+        "n": "start_glassway",
+        "nw": "rain_maker",
+        "s": "tideward_lookout",
+        "sw": "glimmer_field",
         "w": "moonpool"
-      }
+      },
+      "items": [
+        {
+          "name": "Mistcall Bell",
+          "description": "Ringing the bell clears the fog long enough to reveal hidden markers etched into the arches."
+        }
+      ]
     },
     {
       "id": "serpent_bridge",
       "title": "Serpent Bridge",
-      "description": "A sinuous bridge of woven reeds sways above glowing wetlands alive with distant song.",
+      "description": "A sinuous bridge of woven reeds sways above glowing wetlands alive with distant song. Ceramic scales along the railing warm to the touch, remembering every crossing.",
       "exits": {
         "n": "harbor",
+        "s": "reef_gate",
         "w": "mistway"
-      }
+      },
+      "items": [
+        {
+          "name": "Scale Token",
+          "description": "This charm stores the rhythm of your footsteps so the bridge will recognize you on return trips."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Bridge Warden Nira",
+          "auto_greet": "Walk in pace with the music or the reeds will play pranks with the wind."
+        }
+      ]
+    },
+    {
+      "id": "reef_gate",
+      "title": "Reef Gate",
+      "description": "Coral-shaped pillars open like petals toward the sea. Waterlogged runes shimmer along the floor, recording the tides' gossip as they ebb and flow.",
+      "exits": {
+        "e": "serpent_bridge",
+        "n": "tidal_library",
+        "s": "brine_orchard"
+      },
+      "items": [
+        {
+          "name": "Saltscroll",
+          "description": "A roll of kelp parchment that writes down the names of ships glimpsed offshore."
+        }
+      ]
+    },
+    {
+      "id": "moonpool",
+      "title": "Moonpool Court",
+      "description": "Silver water mirrors twin moons that wink whenever a wish sounds sincere enough. Bioluminescent lilies drift across the surface, spelling out predictions in ripples.",
+      "exits": {
+        "e": "mistway",
+        "n": "garden",
+        "s": "tidal_library",
+        "se": "kelp_grotto",
+        "w": "glowroot_labyrinth"
+      },
+      "items": [
+        {
+          "name": "Lunar Pebble",
+          "description": "Tossing the pebble into water reveals a brief vision of the next traveler to arrive."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Oracle Eive",
+          "auto_greet": "Wish clearly—the moon dislikes muddled hearts."
+        }
+      ]
+    },
+    {
+      "id": "kelp_grotto",
+      "title": "Kelp Grotto",
+      "description": "Trailing fronds hang like curtains, hiding alcoves filled with pearlescent seeds. Gentle currents from unseen springs swirl around your ankles, guiding you deeper into the grotto.",
+      "exits": {
+        "nw": "moonpool",
+        "s": "brine_orchard",
+        "w": "tidal_library"
+      },
+      "items": [
+        {
+          "name": "Pearl Seed",
+          "description": "Planting the seed in water grows a temporary stepping stone wherever you need it."
+        }
+      ]
     },
     {
       "id": "tidal_library",
       "title": "Tidal Library",
-      "description": "Shelves float on chained buoys, rising and falling with the surf while waterproof books gossip.",
+      "description": "Shelves float on chained buoys, rising and falling with the surf while waterproof books gossip. Shell librarians swim between stacks, ensuring every tide leaves the right reference at hand.",
       "exits": {
+        "e": "kelp_grotto",
         "n": "harbor",
+        "s": "reef_gate",
         "w": "moonpool"
-      }
+      },
+      "items": [
+        {
+          "name": "Waterproof Codex",
+          "description": "The codex rewrites itself in bubbles that burst into whispered directions when read underwater."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Currentscribe Ola",
+          "auto_greet": "Need a tide table or a lullaby? The shelves know both equally well."
+        }
+      ]
     },
     {
       "id": "root_caves",
       "title": "Root Caves",
-      "description": "Massive roots braid into tunnels lit by fireflies who take attendance of every visitor.",
+      "description": "Massive roots braid into tunnels lit by fireflies who take attendance of every visitor. The earth is soft and warm, humming with the pulse of the trees above.",
       "exits": {
         "d": "ember_grotto",
-        "e": "garden"
-      }
+        "e": "garden",
+        "s": "sap_sanctum"
+      },
+      "items": [
+        {
+          "name": "Root Fiber Rope",
+          "description": "Flexible yet strong, the rope lengthens on command to bridge gaps underground."
+        }
+      ]
+    },
+    {
+      "id": "sap_sanctum",
+      "title": "Sap Sanctum",
+      "description": "Transparent resin flows through twisting channels in the walls, carrying tiny motes of light that narrate the life of every tree in the garden.",
+      "exits": {
+        "e": "spore_chamber",
+        "n": "root_caves",
+        "s": "hanging_bog",
+        "w": "brine_orchard"
+      },
+      "items": [
+        {
+          "name": "Resin Locket",
+          "description": "Seal a memory inside and the locket will replay it in scent and color."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Sapsinger Truun",
+          "auto_greet": "Hold still; the trees wish to hear your pulse alongside their own."
+        }
+      ]
+    },
+    {
+      "id": "hanging_bog",
+      "title": "Hanging Bog",
+      "description": "Platforms of peat sway gently above reflective pools. Mist orchids bloom upside down, releasing spores that glow brighter when lies are spoken nearby.",
+      "exits": {
+        "e": "brine_orchard",
+        "n": "sap_sanctum"
+      },
+      "items": [
+        {
+          "name": "Truthspore Satchel",
+          "description": "A satchel of spores that flares gently whenever deception lingers in the air."
+        }
+      ]
+    },
+    {
+      "id": "brine_orchard",
+      "title": "Brine Orchard",
+      "description": "Salt-tolerant fruit trees twist along the shoreline, their roots drinking from both sea and spring. Clay basins collect brine-sweet nectar to trade with the market's spice merchants.",
+      "exits": {
+        "e": "sap_sanctum",
+        "n": "kelp_grotto",
+        "s": "hanging_bog",
+        "w": "glowroot_labyrinth"
+      },
+      "items": [
+        {
+          "name": "Saltfruit",
+          "description": "A pearlescent fruit whose juice enhances memories of sea journeys when shared."
+        }
+      ]
+    },
+    {
+      "id": "glowroot_labyrinth",
+      "title": "Glowroot Labyrinth",
+      "description": "Roots arch overhead, forming tunnels that rearrange themselves when sung to in the correct key. Bioluminescent fungi pave the twisting path, storing echoes of every conversation.",
+      "exits": {
+        "e": "moonpool",
+        "ne": "garden",
+        "s": "spore_chamber",
+        "w": "brine_orchard"
+      },
+      "items": [
+        {
+          "name": "Glowcap Torch",
+          "description": "A fungal lantern that remembers each fork you take and pulses brighter toward unexplored tunnels."
+        }
+      ]
+    },
+    {
+      "id": "spore_chamber",
+      "title": "Spore Chamber",
+      "description": "Humidity hangs heavy around spiraling racks of spores. Each cluster releases a different vision when inhaled, cataloged meticulously by caretakers who take pride in their precise labeling.",
+      "exits": {
+        "e": "catacomb_nursery",
+        "n": "glowroot_labyrinth",
+        "w": "sap_sanctum"
+      },
+      "items": [
+        {
+          "name": "Vision Vial",
+          "description": "A sealed vial containing spores that reveal memories of the city's founding when opened."
+        }
+      ]
     },
     {
       "id": "catacomb_nursery",
       "title": "Catacomb Nursery",
-      "description": "Clay cradles line alcoves, each nurturing a sapling soul to be replanted in the daylight above.",
+      "description": "Clay cradles line alcoves, each nurturing a sapling soul to be replanted in the daylight above. Lullabies echo in the chamber, sung by caretakers whose voices weave protective wards.",
       "exits": {
         "e": "shadow_vault",
-        "u": "garden"
-      }
+        "u": "garden",
+        "w": "spore_chamber"
+      },
+      "items": [
+        {
+          "name": "Soul Seed",
+          "description": "A carved seed that, when planted, promises to grow into a companion tree tuned to your heartbeat."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Caretaker Umber",
+          "auto_greet": "Hush—the seedlings are dreaming their first steps."
+        }
+      ]
     }
   ]
 }

--- a/data/areas/library.json
+++ b/data/areas/library.json
@@ -4,12 +4,14 @@
     {
       "id": "library",
       "title": "Dustlit Library",
-      "description": "Shelves lean with the weight of forgotten ideas. A faint smell of paper and ozone. Passages branch to specialized wings and an old stairwell spirals upward.",
+      "description": "Shelves lean with the weight of forgotten ideas. A faint smell of paper and ozone lingers as enchanted lanterns drift between stacks, nudging readers toward passages that suit their curiosity. Polished clay floors reflect vaulted ceilings etched with constellations of scholarship.",
       "exits": {
         "e": "scriptorium",
         "n": "astral_gallery",
+        "nw": "lexicon_terrace",
         "s": "start",
-        "u": "observatory"
+        "u": "observatory",
+        "w": "binding_atrium"
       },
       "items": [
         {
@@ -19,133 +21,395 @@
         {
           "name": "Star Chart",
           "description": "Constellations rearrange themselves to trace paths through the stacks."
+        },
+        {
+          "name": "Index Lattice",
+          "description": "A translucent lattice that floats at your elbow, listing relevant references as you think of new topics."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "First Librarian Ellion",
+          "auto_greet": "Knowledge is a kiln—feed it questions and it warms everyone nearby."
         }
       ]
     },
     {
       "id": "scriptorium",
       "title": "Scriptorium of Murmured Ink",
-      "description": "Tall lecterns cradle scrolls that write themselves, quills whispering secrets of visitors past.",
+      "description": "Tall lecterns cradle scrolls that write themselves, quills whispering secrets of visitors past. Ink golems pad softly between desks, offering blank parchment infused with cooperative enchantments.",
       "exits": {
         "e": "illumination_studio",
+        "n": "language_lab",
         "s": "ink_garden",
         "w": "library"
-      }
+      },
+      "items": [
+        {
+          "name": "Self-Turning Page",
+          "description": "A bound page that flips itself to follow along with the text you read aloud."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Copyist Varo",
+          "auto_greet": "Mind the punctuation; it has opinions about where it prefers to rest."
+        }
+      ]
+    },
+    {
+      "id": "language_lab",
+      "title": "Language Laboratory",
+      "description": "Soundproof alcoves hum with translated echoes, letting scholars test new dialects without disturbing their neighbors. Floating consonants shimmer above each workstation, ready to reshape themselves into freshly forged words.",
+      "exits": {
+        "n": "palimpsest_vault",
+        "s": "scriptorium",
+        "w": "lexicon_terrace"
+      },
+      "items": [
+        {
+          "name": "Dialect Prism",
+          "description": "Twist the prism and any sentence spoken nearby rewrites itself into a chosen language."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Linguist Maraen",
+          "auto_greet": "Care to barter a phrase? I collect idioms like other folk collect charms."
+        }
+      ]
     },
     {
       "id": "illumination_studio",
       "title": "Illumination Studio",
-      "description": "Gold leaf dust floats in sunshafts while automatons patiently gild every margin in sight.",
+      "description": "Gold leaf dust floats in sunshafts while automatons patiently gild every margin in sight. Adjustable lenses slide across the windows, tinting the room to match the palette of whichever manuscript is underway.",
       "exits": {
+        "e": "palimpsest_vault",
         "n": "glyph_vault",
         "s": "ink_garden",
         "w": "scriptorium"
-      }
+      },
+      "items": [
+        {
+          "name": "Auric Brush",
+          "description": "A brush that traces light as easily as pigment, perfect for illuminating diagrams."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Gilder Sophine",
+          "auto_greet": "Hold still and I'll frame that idea with a bit of light."
+        }
+      ]
+    },
+    {
+      "id": "palimpsest_vault",
+      "title": "Palimpsest Vault",
+      "description": "Shelves revolve behind translucent screens, revealing layered histories etched one atop the other. Gentle magic keeps the voices of previous scribes murmuring just loud enough to guide careful revision.",
+      "exits": {
+        "n": "atlas_sanctum",
+        "s": "language_lab",
+        "w": "glyph_vault"
+      },
+      "items": [
+        {
+          "name": "Rewriting Stylus",
+          "description": "Touch the stylus to any text and it lifts forgotten drafts for comparison."
+        }
+      ]
     },
     {
       "id": "glyph_vault",
       "title": "Vault of Glyphs",
-      "description": "Shelves of rune-carved stones hum softly, rearranging into new phrases when no one watches.",
+      "description": "Shelves of rune-carved stones hum softly, rearranging into new phrases when no one watches. Suspended glyphs rotate overhead, matching visitors with sigils attuned to their questions.",
       "exits": {
+        "n": "atlas_sanctum",
+        "e": "palimpsest_vault",
         "s": "illumination_studio",
         "w": "ink_garden"
-      }
+      },
+      "items": [
+        {
+          "name": "Rune Rosary",
+          "description": "A loop of glyph-beads that glows when arranged into a protective charm."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Runesmith Tal",
+          "auto_greet": "The stones listen—choose your words with the patience they deserve."
+        }
+      ]
     },
     {
       "id": "ink_garden",
       "title": "Garden of Living Ink",
-      "description": "Vines bloom with characters that drip like dew, spelling compliments to anyone who lingers.",
+      "description": "Vines bloom with characters that drip like dew, spelling compliments to anyone who lingers. Rills of ink wind between stepping stones, offering samples of every color imaginable.",
       "exits": {
         "e": "glyph_vault",
         "n": "scriptorium",
+        "s": "binding_atrium",
         "w": "atelier_dormitory"
-      }
+      },
+      "items": [
+        {
+          "name": "Chromatic Vine",
+          "description": "Snip a tendril and it becomes a quill that writes in whatever shade you hum."
+        }
+      ]
+    },
+    {
+      "id": "binding_atrium",
+      "title": "Binding Atrium",
+      "description": "Stacks of leather, clay, and woven reed rest on rotating tables, each coated with smart resin that molds itself to the reader's grip. Ceiling fans whisper page numbers to aid those assembling bespoke tomes.",
+      "exits": {
+        "e": "library",
+        "n": "lexicon_terrace",
+        "s": "quiet_gallery",
+        "w": "binding_vault"
+      },
+      "items": [
+        {
+          "name": "Spine Clamp",
+          "description": "Clamp a loose stack within and it binds the pages with a ribbon of cooling light."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Binder Iressa",
+          "auto_greet": "Looking for a new cover? Tell me how your story feels in the hand."
+        }
+      ]
+    },
+    {
+      "id": "binding_vault",
+      "title": "Binding Vault",
+      "description": "Quiet alcoves store rare cover materials: dragonhide, glassleaf, and even woven moonlight. Protective wards purr softly, recognizing trustworthy craftsmanship.",
+      "exits": {
+        "e": "binding_atrium",
+        "s": "quiet_gallery"
+      },
+      "items": [
+        {
+          "name": "Moonlight Spool",
+          "description": "Thread spun from moonbeams—perfect for stitching together luminous folios."
+        }
+      ]
+    },
+    {
+      "id": "quiet_gallery",
+      "title": "Quiet Gallery",
+      "description": "Murals of legendary debates line the walls, animated in slow pantomime so as not to disturb the silence. Soundcatchers hang from the ceiling, capturing stray noise and tucking it into decorative jars.",
+      "exits": {
+        "e": "memory_chapel",
+        "n": "binding_vault"
+      },
+      "items": [
+        {
+          "name": "Silence Sash",
+          "description": "Drape it across your shoulders to mute footsteps for an hour."
+        }
+      ]
+    },
+    {
+      "id": "lexicon_terrace",
+      "title": "Lexicon Terrace",
+      "description": "An open-air study lined with shelves of dictionaries in every known tongue. The breeze flips pages that glow briefly, highlighting exactly the definition you require.",
+      "exits": {
+        "e": "language_lab",
+        "ne": "atlas_sanctum",
+        "s": "binding_atrium",
+        "sw": "library"
+      },
+      "items": [
+        {
+          "name": "Glossary Stone",
+          "description": "A smooth stone that translates any overheard word into a whisper only you can hear."
+        }
+      ]
+    },
+    {
+      "id": "atlas_sanctum",
+      "title": "Atlas Sanctum",
+      "description": "Floating globes of clay and light orbit a central dais, each mapping trade winds, ley lines, or hidden caverns. Touching a globe projects a temporary path through the air, complete with annotations and historical footnotes.",
+      "exits": {
+        "n": "celestial_walkway",
+        "s": "astral_gallery",
+        "w": "lexicon_terrace"
+      },
+      "items": [
+        {
+          "name": "Cartographer's Sphere",
+          "description": "A sphere that captures the geography of any region you walk for more than ten heartbeats."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Atlas-Keeper Brehn",
+          "auto_greet": "Name a horizon and I'll show you the roads it dreams of."
+        }
+      ]
     },
     {
       "id": "astral_gallery",
       "title": "Astral Gallery",
-      "description": "Paintings of distant nebulae pulse in real time, sharing borrowed starlight with the hall.",
+      "description": "Paintings of distant nebulae pulse in real time, sharing borrowed starlight with the hall. Glass pedestals hold meteor fragments that hum when passed, harmonizing with the constellations overhead.",
       "exits": {
         "e": "planetarium",
+        "n": "atlas_sanctum",
         "s": "library",
         "w": "memory_chapel"
-      }
+      },
+      "items": [
+        {
+          "name": "Starlit Palette",
+          "description": "Mix a color upon it and the sky outside adopts that hue for a single evening."
+        }
+      ]
     },
     {
       "id": "planetarium",
       "title": "Clockwork Planetarium",
-      "description": "Brass constellations spin overhead, projecting constellations that occasionally wink back.",
+      "description": "Brass constellations spin overhead, projecting patterns that occasionally wink back. Seats carved from cooled meteor iron pivot to follow whichever celestial event the dome highlights.",
       "exits": {
         "u": "celestial_walkway",
         "w": "astral_gallery"
-      }
+      },
+      "items": [
+        {
+          "name": "Orbital Lens",
+          "description": "When held to the eye, it reveals the gravitational threads linking nearby stars."
+        }
+      ]
     },
     {
       "id": "memory_chapel",
       "title": "Chapel of Echoed Memory",
-      "description": "Benches face empty air where voices gather, replaying gratitude offered by travelers long gone.",
+      "description": "Benches face empty air where voices gather, replaying gratitude offered by travelers long gone. Candles shaped like open books float overhead, dimming when solemn vows are spoken.",
       "exits": {
         "d": "echo_archive",
-        "e": "astral_gallery"
-      }
+        "e": "astral_gallery",
+        "w": "quiet_gallery"
+      },
+      "items": [
+        {
+          "name": "Remembering Candle",
+          "description": "Light it and a cherished memory plays in soft light across the chapel floor."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Chaplain Oles",
+          "auto_greet": "Leave a word of thanks; the echoes nourish the shelves as surely as dusting does."
+        }
+      ]
     },
     {
       "id": "echo_archive",
       "title": "Echo Archive",
-      "description": "Rows of crystal cylinders capture laughter, arguments, and lullabies awaiting a new audience.",
+      "description": "Rows of crystal cylinders capture laughter, arguments, and lullabies awaiting a new audience. The air vibrates with stored emotion, ready to be replayed for historians or homesick travelers.",
       "exits": {
         "u": "memory_chapel"
-      }
+      },
+      "items": [
+        {
+          "name": "Echo Cylinder",
+          "description": "A portable cylinder that can store a single spoken sentence for posterity."
+        }
+      ]
     },
     {
       "id": "observatory",
       "title": "Windworn Observatory",
-      "description": "An aged telescope peers through a ragged aperture; faint comets leave notes in its ledger.",
+      "description": "An aged telescope peers through a ragged aperture; faint comets leave notes in its ledger. Sails of silk drift overhead, capturing stray starlight to power the instruments at night.",
       "exits": {
         "d": "library",
         "e": "celestial_walkway",
         "n": "skybridge"
-      }
+      },
+      "items": [
+        {
+          "name": "Star Ledger",
+          "description": "Entries appear on the ledger whenever a new celestial event is observed from anywhere in the city."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Astrolabe Keeper Vin",
+          "auto_greet": "If the stars frown tonight, we'll brew tea until they forgive us."
+        }
+      ]
     },
     {
       "id": "celestial_walkway",
       "title": "Celestial Walkway",
-      "description": "A glass-floored bridge floats through a pocket of gravity, stars drifting lazily beneath your boots.",
+      "description": "A glass-floored bridge floats through a pocket of gravity, stars drifting lazily beneath your boots. Brass filigree along the railing records the names of those who dared to look straight down without flinching.",
       "exits": {
         "d": "planetarium",
         "e": "skybridge",
+        "s": "atlas_sanctum",
         "w": "observatory"
-      }
+      },
+      "items": [
+        {
+          "name": "Gravity Bauble",
+          "description": "Release it and it orbits your shoulders, keeping you steady on narrow bridges."
+        }
+      ]
     },
     {
       "id": "skybridge",
       "title": "Skybridge of Lanterns",
-      "description": "Wind-bells stitched from constellations chime, guiding wanderers toward higher, brighter places.",
+      "description": "Wind-bells stitched from constellations chime, guiding wanderers toward higher, brighter places. Suspended lanterns gently adjust their glow to match the courage of those crossing.",
       "exits": {
         "e": "balloon_roost",
         "n": "cloud_dock",
         "s": "observatory",
         "w": "celestial_walkway"
-      }
+      },
+      "items": [
+        {
+          "name": "Lantern Tassel",
+          "description": "Tie it to your pack and the skybridge will always brighten a bit more for you."
+        }
+      ]
     },
     {
       "id": "cloud_dock",
       "title": "Cloud Dock",
-      "description": "Tethers secure zephyrs like ships, each labeled with a destination written in vapor.",
+      "description": "Tethers secure zephyrs like ships, each labeled with a destination written in vapor. Dockhands weave nets of wind to catch stray breezes before they drift into the market below.",
       "exits": {
         "d": "harbor_lighthouse",
         "s": "skybridge",
         "w": "clocktower_belfry"
-      }
+      },
+      "items": [
+        {
+          "name": "Wind Ticket",
+          "description": "A stamped ticket that entitles the bearer to a one-way gust toward any district spire."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Dockmaster Ril",
+          "auto_greet": "You're just in time—the west wind volunteered to carry guests to the market."
+        }
+      ]
     },
     {
       "id": "balloon_roost",
       "title": "Balloon Roost",
-      "description": "Deflated exploration balloons roost like sleeping birds, dreaming of tomorrow's discoveries.",
+      "description": "Deflated exploration balloons roost like sleeping birds, dreaming of tomorrow's discoveries. Racks of spare silk and sandbag charms await the next expedition's tailoring.",
       "exits": {
         "s": "loft",
         "w": "skybridge"
-      }
+      },
+      "items": [
+        {
+          "name": "Sandbag Charm",
+          "description": "Whisper a destination and the charm lightens or weights your pack to keep you level in flight."
+        }
+      ]
     }
   ]
 }

--- a/data/areas/market.json
+++ b/data/areas/market.json
@@ -4,12 +4,14 @@
     {
       "id": "market",
       "title": "Silent Market",
-      "description": "Stalls stand ready for traders that never quite arrive.",
+      "description": "Stalls stand ready for traders that never quite arrive. Awning cords sway in the breeze, playing soft chords that echo across the plaza. Chalk markings on the stones update themselves with the day's recommended bargains.",
       "exits": {
         "d": "vaulted_storage",
         "e": "start",
         "n": "parade",
+        "ne": "start_cartographers_post",
         "s": "harbor",
+        "se": "market_prism_gate",
         "w": "clocktower"
       },
       "items": [
@@ -20,104 +22,327 @@
         {
           "name": "String of Chimes",
           "description": "Each bell rings a different currency when shaken."
+        },
+        {
+          "name": "Merchant's Beacon",
+          "description": "Set it beside a stall and it projects a hologram advertising your wares."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Broker Nal",
+          "auto_greet": "Prices are low, stakes are high—care to barter with ghosts of buyers yet to come?"
+        }
+      ]
+    },
+    {
+      "id": "market_prism_gate",
+      "title": "Prism Gate",
+      "description": "A crystalline arch captures light from the Glassway, refracting it into ribbons that label each stall with floating sigils. Couriers pause here to exchange sealed route markers before diving back into the city's traffic.",
+      "exits": {
+        "n": "market",
+        "e": "auric_arcade",
+        "s": "harbor_market",
+        "w": "start_glassway"
+      },
+      "items": [
+        {
+          "name": "Route Marker",
+          "description": "Snap the marker in half to share a temporary shortcut with an ally."
+        }
+      ]
+    },
+    {
+      "id": "auric_arcade",
+      "title": "Auric Arcade",
+      "description": "A covered walkway glittering with gilded mosaics showcases artisans specializing in jewelry and rare metals. Mirrors angle sunlight to spotlight each display even on cloudy days.",
+      "exits": {
+        "n": "parade",
+        "e": "ledger_gallery",
+        "s": "harbor_market",
+        "w": "market_prism_gate"
+      },
+      "items": [
+        {
+          "name": "Gemscope",
+          "description": "Peer through it to see the ethical history of any gem you inspect."
+        }
+      ]
+    },
+    {
+      "id": "ledger_gallery",
+      "title": "Ledger Gallery",
+      "description": "Suspended ledgers rotate slowly, offering transparent pages that reveal trade histories at a touch. Whispered deals flutter through the air like pages turned by invisible fingers.",
+      "exits": {
+        "e": "tinker_lane",
+        "n": "merchant_guildhall",
+        "w": "auric_arcade"
+      },
+      "items": [
+        {
+          "name": "Balance Abacus",
+          "description": "Sliding the beads forecasts profit margins for any proposed trade."
+        }
+      ]
+    },
+    {
+      "id": "merchant_guildhall",
+      "title": "Merchant Guildhall",
+      "description": "Grand banners hang from vaulted ceilings, each representing a guild sworn to uphold fair trade. Negotiation tables ringed with comfortable chairs await delegates seeking compromise.",
+      "exits": {
+        "e": "festival_stage",
+        "s": "ledger_gallery",
+        "w": "parade"
+      },
+      "items": [
+        {
+          "name": "Guild Seal",
+          "description": "A seal that temporarily grants you the backing of the guildhall during negotiations."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Guildmaster Pahr",
+          "auto_greet": "Speak plainly, bargain fairly, and the guild will ensure your ledger ends in black."
+        }
+      ]
+    },
+    {
+      "id": "tinker_lane",
+      "title": "Tinker Lane",
+      "description": "Cobblestones vibrate with the purr of clockwork toys weaving between stalls. Portable workbenches line the lane, offering repairs while you wait.",
+      "exits": {
+        "e": "saffron_colonnade",
+        "s": "whispering_alley",
+        "w": "ledger_gallery"
+      },
+      "items": [
+        {
+          "name": "Clockwork Charm",
+          "description": "Attach it to any device and it gains a polite personality for a day."
+        }
+      ]
+    },
+    {
+      "id": "saffron_colonnade",
+      "title": "Saffron Colonnade",
+      "description": "Columns wrapped in fragrant spice garlands color the air with shades of amber and crimson. Lanterns shaped like pepper pods blink encouragingly at hesitant buyers.",
+      "exits": {
+        "n": "festival_stage",
+        "s": "harbor_market",
+        "w": "tinker_lane"
+      },
+      "items": [
+        {
+          "name": "Spice Sampler",
+          "description": "A tray of powders that, when sprinkled, recreates the scent of distant markets."
+        }
+      ]
+    },
+    {
+      "id": "harbor_market",
+      "title": "Harbor Market",
+      "description": "Covered stalls serve sailors and skyfarers, trading salted delicacies and glowing kelp. Tide bells ring softly to announce incoming shipments.",
+      "exits": {
+        "e": "salt_exchange",
+        "n": "saffron_colonnade",
+        "s": "harbor",
+        "w": "market_prism_gate"
+      },
+      "items": [
+        {
+          "name": "Cargo Scrip",
+          "description": "Redeemable for transport of a single crate on the next tide-runner."
+        }
+      ]
+    },
+    {
+      "id": "salt_exchange",
+      "title": "Salt Exchange",
+      "description": "Vaulted alcoves store rare salts that shimmer in hues from violet to jade. Traders test samples on carved tasting stones that flash when the mineral suits their needs.",
+      "exits": {
+        "w": "harbor_market",
+        "s": "harbor"
+      },
+      "items": [
+        {
+          "name": "Prism Salt",
+          "description": "A pinch seasons food and briefly lets the diner breathe underwater."
         }
       ]
     },
     {
       "id": "clocktower",
       "title": "Clocktower Plaza",
-      "description": "Bronze numerals circle overhead, raining punctuality on anyone who lingers too long.",
+      "description": "Bronze numerals circle overhead, raining punctuality on anyone who lingers too long. A gentle ticking pulses through the plaza, syncing with every heartbeat nearby.",
       "exits": {
         "e": "market",
-        "u": "clocktower_belfry",
-        "w": "gearworks"
-      }
+        "s": "gearworks",
+        "u": "clocktower_belfry"
+      },
+      "items": [
+        {
+          "name": "Minute Hammer",
+          "description": "Tap a surface to reset the local timepiece network by a single minute."
+        }
+      ]
     },
     {
       "id": "clocktower_belfry",
       "title": "Clocktower Belfry",
-      "description": "Giant chimes hang silent between beats, storing up the next note like a held breath.",
+      "description": "Giant chimes hang silent between beats, storing up the next note like a held breath. Swirling glyphs chart the winds, guiding messages between the tower and the observatory.",
       "exits": {
         "d": "clocktower",
-        "e": "cloud_dock"
-      }
+        "e": "cloud_dock",
+        "w": "calibration_bridge"
+      },
+      "items": [
+        {
+          "name": "Echo Mallet",
+          "description": "Strike a bell and its tone repeats every hour until silenced."
+        }
+      ]
     },
     {
       "id": "parade",
       "title": "Parade Concourse",
-      "description": "Banners ripple despite the still air, rehearsing applause for the next celebration.",
+      "description": "Banners ripple despite the still air, rehearsing applause for the next celebration. Painted footprints on the stones teach dancers new steps overnight.",
       "exits": {
         "e": "lantern_row",
         "n": "festival_stage",
+        "ne": "auric_arcade",
         "s": "market",
         "w": "whispering_alley"
-      }
+      },
+      "items": [
+        {
+          "name": "Festival Baton",
+          "description": "Wave it and the banners coordinate in dazzling synchronized patterns."
+        }
+      ]
     },
     {
       "id": "festival_stage",
       "title": "Festival Stage",
-      "description": "A polished wooden stage awaits performers, enchanted spotlights following whoever dares step up.",
+      "description": "A polished wooden stage awaits performers, enchanted spotlights following whoever dares step up. Backstage curtains hide dressing rooms sized for both giants and sprites.",
       "exits": {
-        "s": "parade"
-      }
+        "s": "parade",
+        "w": "merchant_guildhall"
+      },
+      "items": [
+        {
+          "name": "Encore Mask",
+          "description": "Wearing the mask ensures the crowd demands an encore after any performance."
+        }
+      ]
     },
     {
       "id": "lantern_row",
       "title": "Lantern Row",
-      "description": "Paper lanterns float at shoulder height, escorting wanderers between market and garden paths.",
+      "description": "Paper lanterns float at shoulder height, escorting wanderers between market and garden paths. Each lantern hums a different lullaby learned from the garden's night blossoms.",
       "exits": {
         "e": "atelier_dormitory",
         "s": "glasshouse",
         "w": "parade"
-      }
+      },
+      "items": [
+        {
+          "name": "Guiding Lantern",
+          "description": "It remembers the last safe route you walked and can replay the journey as a light-trail."
+        }
+      ]
     },
     {
       "id": "whispering_alley",
       "title": "Whispering Alley",
-      "description": "Shuttered stalls gossip quietly, trading secrets as casually as coins.",
+      "description": "Shuttered stalls gossip quietly, trading secrets as casually as coins. The cobbles are etched with coded symbols for smugglers who still owe favors to the market.",
       "exits": {
         "e": "parade",
-        "n": "shadow_vault"
-      }
+        "n": "shadow_vault",
+        "w": "tinker_lane"
+      },
+      "items": [
+        {
+          "name": "Secret Ledger",
+          "description": "Flip to any page and it reveals the last clandestine trade recorded there."
+        }
+      ]
     },
     {
       "id": "harbor",
       "title": "Harbor of Gentle Tides",
-      "description": "Bioluminescent currents lap at rune-carved docks where tide charts hum reassuring lullabies.",
+      "description": "Bioluminescent currents lap at rune-carved docks where tide charts hum reassuring lullabies. Mooring lines tie themselves in tidy knots whenever a ship arrives.",
       "exits": {
         "e": "serpent_bridge",
         "n": "market",
+        "ne": "harbor_market",
         "s": "tidal_library",
         "w": "harbor_lighthouse"
-      }
+      },
+      "items": [
+        {
+          "name": "Tide Compass",
+          "description": "The compass needle points toward the next incoming vessel."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Harbormaster Siel",
+          "auto_greet": "Keep your paperwork dry and your promises drier."
+        }
+      ]
     },
     {
       "id": "harbor_lighthouse",
       "title": "Harbor Lighthouse",
-      "description": "A spiral beacon spins quiet halos, guiding both ships and errant daydreams back to shore.",
+      "description": "A spiral beacon spins quiet halos, guiding both ships and errant daydreams back to shore. Shelves of polished lenses rest against the wall, ready to swap in for different weather.",
       "exits": {
         "e": "harbor",
         "u": "cloud_dock"
-      }
+      },
+      "items": [
+        {
+          "name": "Beacon Lens",
+          "description": "Slot it into the lighthouse lamp to send customized light signals across the bay."
+        }
+      ]
     },
     {
       "id": "vaulted_storage",
       "title": "Vaulted Storage",
-      "description": "Crates levitate just above the floor, labeled in tidy handwriting that rearranges itself.",
+      "description": "Crates levitate just above the floor, labeled in tidy handwriting that rearranges itself. Weightless lifts glide up and down between mezzanines stacked with carefully cataloged goods.",
       "exits": {
         "s": "shadow_vault",
         "u": "market"
-      }
+      },
+      "items": [
+        {
+          "name": "Inventory Ledger",
+          "description": "Consult it to know exactly where any stored crate currently floats."
+        }
+      ]
     },
     {
       "id": "shadow_vault",
       "title": "Shadow Vault",
-      "description": "Cool darkness keeps rare curios safe; shadows queue patiently to be borrowed for disguises.",
+      "description": "Cool darkness keeps rare curios safe; shadows queue patiently to be borrowed for disguises. A whisper of silk hints at unseen attendants managing the secrecy of every deposit.",
       "exits": {
         "n": "vaulted_storage",
         "s": "whispering_alley",
         "w": "catacomb_nursery"
-      }
+      },
+      "items": [
+        {
+          "name": "Veil Token",
+          "description": "Hold it and nearby shadows twine around you like a cloak."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Shadow Curator Illin",
+          "auto_greet": "Your secrets are safe so long as you remember where you left them."
+        }
+      ]
     }
   ]
 }

--- a/data/areas/observatory.json
+++ b/data/areas/observatory.json
@@ -20,7 +20,7 @@
       "npcs": [
         {
           "name": "Starcall Adept",
-          "auto_greet": "Mind your step—each stone remembers where the sky once opened."
+          "auto_greet": "Mind your step\u2014each stone remembers where the sky once opened."
         }
       ]
     },
@@ -59,7 +59,7 @@
       "npcs": [
         {
           "name": "Archivist of Echoes",
-          "auto_greet": "Hush—the constellations are transcribing our conversation as we speak."
+          "auto_greet": "Hush\u2014the constellations are transcribing our conversation as we speak."
         }
       ]
     },
@@ -81,7 +81,7 @@
       "npcs": [
         {
           "name": "Lenswright Mara",
-          "auto_greet": "If you find a mote of dust, return it—it may have wandered in from a comet."
+          "auto_greet": "If you find a mote of dust, return it\u2014it may have wandered in from a comet."
         }
       ]
     },
@@ -118,7 +118,7 @@
       "npcs": [
         {
           "name": "Hydromancer Vele",
-          "auto_greet": "Careful—every ripple writes a new prediction across the stars above."
+          "auto_greet": "Careful\u2014every ripple writes a new prediction across the stars above."
         }
       ]
     },
@@ -163,7 +163,7 @@
       "npcs": [
         {
           "name": "Lightcaster's Echo",
-          "auto_greet": "Mind the shutters—each note of light carries a message waiting to be returned."
+          "auto_greet": "Mind the shutters\u2014each note of light carries a message waiting to be returned."
         }
       ]
     },
@@ -202,7 +202,7 @@
       "npcs": [
         {
           "name": "Professor Orrin Aster",
-          "auto_greet": "Ah, a visitor! Tell me—have the stars been courteous tonight, or must I file another complaint?"
+          "auto_greet": "Ah, a visitor! Tell me\u2014have the stars been courteous tonight, or must I file another complaint?"
         }
       ]
     },
@@ -222,7 +222,7 @@
       "npcs": [
         {
           "name": "Beacon Keeper Iress",
-          "auto_greet": "Stand close—the lanterns speak of which travelers will find their way home tonight."
+          "auto_greet": "Stand close\u2014the lanterns speak of which travelers will find their way home tonight."
         }
       ]
     },
@@ -233,7 +233,8 @@
       "exits": {
         "w": "observatory_dome",
         "nw": "observatory_spire",
-        "d": "observatory_starwell"
+        "d": "observatory_starwell",
+        "sw": "start_aurora_balcony"
       },
       "items": [
         {
@@ -276,7 +277,7 @@
       "npcs": [
         {
           "name": "Resonant Custodian",
-          "auto_greet": "Match the pitch in your chest—the vault only shares its secrets with those in tune."
+          "auto_greet": "Match the pitch in your chest\u2014the vault only shares its secrets with those in tune."
         }
       ]
     },

--- a/data/areas/start.json
+++ b/data/areas/start.json
@@ -4,20 +4,22 @@
     {
       "id": "start",
       "title": "Luminal Confluence",
-      "description": "The atrium blooms like a kiln-flower in mid-ignite, petals of fired clay suspended in the air by threads of slow-moving light. Translucent veins of azure lumen pulse beneath your feet, warming the inlaid mosaic that charts the four surrounding districts. Pillared arcades shimmer to the north, east, south, and west—each arch banded with glyphs that name the library, workshop, garden, and market beyond. Overhead, a lattice of glassleaf panels refracts gentle daylight into motes that drift like curious fireflies, while a low, resonant hum rises from the vents of an unseen crucible below.",
+      "description": "The atrium blooms like a kiln-flower in mid-ignite, petals of fired clay suspended in the air by threads of slow-moving light. Translucent veins of azure lumen pulse beneath your feet, warming the inlaid mosaic that charts the neighboring districts and the vaulted chambers hidden below. Pillared arcades shimmer to the north, east, south, and west—each arch banded with glyphs that name the library, workshop, garden, and market beyond. Overhead, a lattice of glassleaf panels refracts daylight into motes that drift like curious fireflies while drifting chords from unseen chimes keep time with the heartbeats of the city.",
       "exits": {
+        "d": "start_reservoir",
         "e": "workshop",
         "n": "library",
+        "ne": "start_colonnade",
+        "nw": "start_archive",
         "s": "garden",
-        "w": "market",
+        "se": "start_transitarium",
         "u": "start_overlook",
-        "d": "start_reservoir",
-        "nw": "start_archive"
+        "w": "market"
       },
       "items": [
         {
           "name": "Chorale Crucible",
-          "description": "A waist-high vessel of porous clay sings a soft three-note chord whenever someone steps near, sending ripples of light racing through the floor mosaic."
+          "description": "A waist-high vessel of porous clay sings a soft triad whenever someone steps near, sending ripples of light racing through the floor mosaic."
         },
         {
           "name": "Lumen Petals",
@@ -26,12 +28,20 @@
         {
           "name": "Compass of Embers",
           "description": "This bronze compass bears four glowing arrows that brighten when pointed toward the districts they represent, inviting exploration."
+        },
+        {
+          "name": "Mnemonic Thread",
+          "description": "A ribbon of woven light that loops around your wrist and records every doorway you pass with a gentle pulse."
         }
       ],
       "npcs": [
         {
           "name": "Glazecaller Ilyss",
           "auto_greet": "Welcome, shaper of light. Let the clay remember your touch and the city will remember your name."
+        },
+        {
+          "name": "Wayfinder Ghal",
+          "auto_greet": "New paths have opened today. I can hum their resonances for you if you promise to return with a story."
         }
       ]
     },
@@ -41,13 +51,18 @@
       "description": "A sloped ramp of vitrified clay climbs to a balcony ringed with prism spires. From here the entire atrium gleams like a living kiln, its shifting hues mirrored in a suspended basin of liquid glass above. Hushed voices drift from artisans tracing designs into hanging light-sheets, their patterns forming new guild sigils in mid-air.",
       "exits": {
         "d": "start",
-        "ne": "start_gallery",
-        "n": "observatory_plaza"
+        "e": "start_colonnade",
+        "n": "observatory_plaza",
+        "ne": "start_gallery"
       },
       "items": [
         {
           "name": "Harmonic Stylus",
           "description": "A slim rod of polished obsidian that, when waved, leaves a lingering ribbon of color that slowly twists back into the ambient glow."
+        },
+        {
+          "name": "Glassleaf Monocle",
+          "description": "Looking through the monocle reveals drifting annotations that identify every artisan visible from the balcony."
         }
       ]
     },
@@ -56,28 +71,45 @@
       "title": "Gallery of Fired Memories",
       "description": "Shelves carved directly from the wall cradle amphorae and tiles infused with bioluminescent glaze. Each piece flickers to life as you pass, reenacting the memory of its creation: hands shaping clay, sparks leaping, rain hissing against hot stone. The air tastes faintly of mineral rain and sweet kiln smoke.",
       "exits": {
-        "sw": "start_overlook",
-        "s": "start"
+        "e": "start_cartographers_post",
+        "n": "start_radiant_gallery",
+        "s": "start",
+        "sw": "start_overlook"
       },
       "items": [
         {
           "name": "Memory Tile",
           "description": "A warm tile that replays a vivid scene of apprentices rescuing a collapsed sculpture by weaving beams of light to hold it upright."
+        },
+        {
+          "name": "Kilnshard Pendant",
+          "description": "The pendant glows whenever it hears a tale it has not yet stored, eager to collect fresh triumphs."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Curator Silma",
+          "auto_greet": "Careful where you look—the memories might ask you to finish what they began."
         }
       ]
     },
     {
       "id": "start_reservoir",
       "title": "Lumen Reservoir",
-      "description": "Descending beneath the atrium, you find a vaulted chamber where canals of liquid light circulate through terraced pools. Clay golems in various states of completion rest upon turning plinths, their hollows filling with glow as the reservoirs cycle. The gentle churn of lumen through porous stone creates a steady heartbeat for the city above.",
+      "description": "Descending beneath the atrium, you find a vaulted chamber where canals of liquid light circulate through terraced pools. Clay golems in various states of completion rest upon turning plinths, their hollows filling with glow as the reservoirs cycle. The gentle churn of lumen through porous stone creates a steady heartbeat for the city above, echoing through the spiral conduits that carry power outward.",
       "exits": {
-        "u": "start",
-        "ne": "start_archive"
+        "e": "start_resonance_walk",
+        "ne": "start_archive",
+        "u": "start"
       },
       "items": [
         {
           "name": "Resonant Ladle",
           "description": "A heavy ladle whose bowl traps a sphere of luminescence; when poured, it paints temporary sigils across the pool's surface."
+        },
+        {
+          "name": "Pulse Gauge",
+          "description": "This translucent tool measures the rhythm of the lumen tides and hums warnings when the flow stutters."
         }
       ],
       "npcs": [
@@ -93,6 +125,10 @@
               "description": "A fist-sized crystal humming with the reservoir's tempered light."
             }
           ]
+        },
+        {
+          "name": "Flowchart Acolyte",
+          "auto_greet": "Mind the conduits—the lumen remembers every hand that guides it."
         }
       ]
     },
@@ -101,6 +137,8 @@
       "title": "Glyphwork Archive",
       "description": "Narrow aisles wind between towering stacks of clay tablets, each etched with radiant grooves that drift like ink when read aloud. Whispered annotations from distant archivists answer your curiosity, their voices traveling along silver threads stretched between the shelves. An alcove contains a drafting table strewn with unfinished scripts awaiting new histories.",
       "exits": {
+        "e": "start_lyricwell",
+        "n": "start_chronicle",
         "se": "start",
         "sw": "start_reservoir"
       },
@@ -108,12 +146,238 @@
         {
           "name": "Scriptor's Prism",
           "description": "A multifaceted prism that reveals hidden notes when its light is cast through the glyphs on any tablet."
+        },
+        {
+          "name": "Borrowed Promise",
+          "description": "A clay seal that, once broken, reminds the holder of an oath pledged somewhere else in the city."
         }
       ],
       "npcs": [
         {
           "name": "Archivist Thalen",
           "auto_greet": "Careful with the tablets—every line is a promise the clay agreed to keep."
+        }
+      ]
+    },
+    {
+      "id": "start_colonnade",
+      "title": "Colonnade of Whispered Steps",
+      "description": "A crescent of slender pillars fans out from the atrium, their surfaces inlaid with tessellated mirrors that echo footsteps a heartbeat after they are taken. Lanterns shaped like folded origami brighten in sequence ahead of any traveler, sketching a path toward distant wings of the city.",
+      "exits": {
+        "e": "library",
+        "n": "start_lyricwell",
+        "sw": "start",
+        "w": "start_overlook"
+      },
+      "items": [
+        {
+          "name": "Echo Lantern",
+          "description": "A palm-sized lamp that repeats a soft chime for each person currently walking the colonnade."
+        }
+      ]
+    },
+    {
+      "id": "start_lyricwell",
+      "title": "Lyricwell Rotunda",
+      "description": "An artesian spring of liquid light wells up through a circular dais, its surface rippling with notation that drifts off to ornament the walls. Choir stalls carved into the surrounding pillars resonate with whispered melodies, teaching visitors to harmonize with the city's pulse.",
+      "exits": {
+        "e": "start_resonance_walk",
+        "s": "start_colonnade",
+        "w": "start_archive"
+      },
+      "items": [
+        {
+          "name": "Harmonic Draught",
+          "description": "A crystal vial filled with liquid song; one sip allows you to mimic any melody you have heard."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Cantor Myrene",
+          "auto_greet": "Sing with the spring and it will sing the future back to you."
+        }
+      ]
+    },
+    {
+      "id": "start_resonance_walk",
+      "title": "Resonance Walk",
+      "description": "Parallel channels of luminant water braid beneath a suspended walkway of translucent clay. Every stride sends harmonics along the rails, awakening murals that illustrate the city's hidden aquifers.",
+      "exits": {
+        "e": "start_planisphere",
+        "n": "start_harmonic_chamber",
+        "s": "start_reservoir",
+        "w": "start_lyricwell"
+      },
+      "items": [
+        {
+          "name": "Surveyor's Anklet",
+          "description": "Woven from copper wire and kiln string, it vibrates when an uncharted tunnel lies nearby."
+        }
+      ]
+    },
+    {
+      "id": "start_planisphere",
+      "title": "Planisphere Promenade",
+      "description": "A circular platform is inlaid with concentric rings that rotate beneath your boots, aligning miniature constellations with the district sigils engraved along the balustrade. Each ring pulses with light when an adjoining pathway is explored, recording your travels in gentle luminescence.",
+      "exits": {
+        "n": "start_celestium",
+        "s": "start_transitarium",
+        "w": "start_resonance_walk"
+      },
+      "items": [
+        {
+          "name": "Rotational Orrery",
+          "description": "A handheld device whose arms swivel to point toward any room you have already visited today."
+        }
+      ]
+    },
+    {
+      "id": "start_harmonic_chamber",
+      "title": "Harmonic Chamber",
+      "description": "A vaulted hall hung with ceramic bells that sway in invisible breezes. Crossing the chamber sends shivers of sound spiraling upward, where sculpted resonators capture and store the harmonies as shimmering droplets.",
+      "exits": {
+        "e": "start_celestium",
+        "s": "start_resonance_walk",
+        "w": "start_chronicle"
+      },
+      "items": [
+        {
+          "name": "Tonekeeper Bell",
+          "description": "A palm-sized bell that retains the last harmony it heard; when rung it replays the captured chord perfectly."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Conductor Vhail",
+          "auto_greet": "Hold the rhythm steady and the city will breathe easier."
+        }
+      ]
+    },
+    {
+      "id": "start_celestium",
+      "title": "Celestium Vault",
+      "description": "Crystalline ribs arch overhead to form a luminous dome mapped with constellations. Threads of light descend to touch the floor, weaving temporary models of routes between the districts and the heavens beyond the observatory.",
+      "exits": {
+        "e": "start_aurora_balcony",
+        "s": "start_planisphere",
+        "w": "start_harmonic_chamber"
+      },
+      "items": [
+        {
+          "name": "Stellar Loom",
+          "description": "A portable loom that spins comet-light into cords sturdy enough to anchor floating walkways."
+        }
+      ]
+    },
+    {
+      "id": "start_aurora_balcony",
+      "title": "Aurora Balcony",
+      "description": "An open balcony catches the upper winds, its railing adorned with ribboned lenses that tint the horizon with auroral hues. Far below, the districts glitter in miniature while the observatory's silent instruments pivot in greeting.",
+      "exits": {
+        "e": "observatory_signal_gallery",
+        "s": "start_radiant_gallery",
+        "w": "start_celestium"
+      },
+      "items": [
+        {
+          "name": "Skylens Garland",
+          "description": "Garlands of lens-petals absorb starlight during the night and release it as soft illumination at dawn."
+        }
+      ]
+    },
+    {
+      "id": "start_transitarium",
+      "title": "Transitarium",
+      "description": "Circular rails inlaid within the floor rotate entire sections of wall, revealing portals keyed to workshops, markets, and botanical sanctuaries. Mechanical guides rest in alcoves until summoned, their clay shells painted with maps that update themselves with each new discovery.",
+      "exits": {
+        "e": "start_cartographers_post",
+        "n": "start_planisphere",
+        "s": "start_glassway",
+        "w": "start"
+      },
+      "items": [
+        {
+          "name": "Route Codex",
+          "description": "A hexagonal book whose pages shuffle to display the optimal route between any two known rooms."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Porter Automaton",
+          "auto_greet": "Please state your destination, and I shall align the doors accordingly."
+        }
+      ]
+    },
+    {
+      "id": "start_cartographers_post",
+      "title": "Cartographer's Post",
+      "description": "Tables of suspended parchment drift at waist height, each inscribed with cartographic glyphs that redraw themselves as new explorations occur. Brass arms fitted with ink reservoirs trace glowing lines, stitching the districts together.",
+      "exits": {
+        "e": "start_glassway",
+        "n": "start_gallery",
+        "sw": "market",
+        "w": "start_transitarium"
+      },
+      "items": [
+        {
+          "name": "Ink Spheroid",
+          "description": "A levitating orb of luminescent ink that can be coaxed into revealing hidden passageways on any map."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Survey-Mage Pell",
+          "auto_greet": "If you chart a new route, leave a signature—our maps enjoy knowing who taught them to grow."
+        }
+      ]
+    },
+    {
+      "id": "start_glassway",
+      "title": "Glassway Causeway",
+      "description": "A translucent bridge arcs toward the outlying districts, its underside alive with darting lightfish that chase one another in looping patterns. Footsteps set the railings aglow, broadcasting the traveler's direction toward the market and the garden.",
+      "exits": {
+        "e": "market_prism_gate",
+        "n": "start_transitarium",
+        "s": "mistway",
+        "w": "start_cartographers_post"
+      },
+      "items": [
+        {
+          "name": "Bridge Baton",
+          "description": "Tap the baton on the railing to summon a temporary shield of glassleaf panels against inclement weather."
+        }
+      ]
+    },
+    {
+      "id": "start_chronicle",
+      "title": "Chronicle Scriptorium",
+      "description": "Banks of suspended scrolls slowly unroll and rewrite themselves as the city's story grows. Inked silhouettes replay the triumphs and missteps of travelers, ensuring the atrium never forgets the lessons of its guests.",
+      "exits": {
+        "e": "start_harmonic_chamber",
+        "n": "start_radiant_gallery",
+        "s": "start_archive"
+      },
+      "items": [
+        {
+          "name": "Annals Ribbon",
+          "description": "A ribbon of flexible clay that imprints a summary of your accomplishments when warmed in your hands."
+        }
+      ]
+    },
+    {
+      "id": "start_radiant_gallery",
+      "title": "Radiant Gallery",
+      "description": "Sculptures of translucent porcelain capture frozen moments of the aurora, each piece emitting a low hum that harmonizes with its neighbors. Light spills through etched louvers overhead, bathing the room in watercolor hues.",
+      "exits": {
+        "e": "start_celestium",
+        "s": "start_chronicle",
+        "w": "start_gallery",
+        "n": "start_aurora_balcony"
+      },
+      "items": [
+        {
+          "name": "Auroral Chisel",
+          "description": "This tool carves light directly from the air, shaping it into temporary sculptures that fade with the dawn."
         }
       ]
     }

--- a/data/areas/workshop.json
+++ b/data/areas/workshop.json
@@ -4,11 +4,12 @@
     {
       "id": "workshop",
       "title": "Crackle Workshop",
-      "description": "Benches, tools, and half-built contraptions hum with patient possibility.",
+      "description": "Benches, tools, and half-built contraptions hum with patient possibility. Overhead pulleys shuttle trays of glowing components while chalk-sketched diagrams redraw themselves whenever a better idea sparks.",
       "exits": {
         "e": "forge",
         "n": "gearworks",
         "s": "atelier_dormitory",
+        "se": "prototype_gallery",
         "u": "loft",
         "w": "start"
       },
@@ -20,99 +21,337 @@
         {
           "name": "Soldering Wand",
           "description": "Its tip glows when it senses an unfinished invention."
+        },
+        {
+          "name": "Schematic Slate",
+          "description": "Sketch an idea and the slate projects a three-dimensional preview above the table."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Foreman Rel",
+          "auto_greet": "Bring me a problem and I'll loan you the right solution, or at least the right wrench."
         }
       ]
     },
     {
       "id": "gearworks",
       "title": "Gearworks Atrium",
-      "description": "Floor-to-ceiling cogs lazily rotate in polite applause for every tinkerer who passes by.",
+      "description": "Floor-to-ceiling cogs lazily rotate in polite applause for every tinkerer who passes by. Copper pistons keep time with a steady beat that syncs the entire complex.",
       "exits": {
         "e": "cogspring",
         "s": "workshop",
+        "u": "gearworks_mezzanine",
         "w": "clocktower"
-      }
+      },
+      "items": [
+        {
+          "name": "Calibration Cog",
+          "description": "A palm-sized cog that adjusts itself to mesh with any gear you press it against."
+        }
+      ]
+    },
+    {
+      "id": "gearworks_mezzanine",
+      "title": "Gearworks Mezzanine",
+      "description": "A suspended balcony offers a bird's-eye view of the atrium. Suspended gauges track tension in every chain, whispering warnings before jams can occur.",
+      "exits": {
+        "d": "gearworks",
+        "e": "calibration_bridge"
+      },
+      "items": [
+        {
+          "name": "Overseer Lens",
+          "description": "Looking through the lens highlights any component overdue for maintenance."
+        }
+      ]
+    },
+    {
+      "id": "calibration_bridge",
+      "title": "Calibration Bridge",
+      "description": "A narrow catwalk spans the open air between the workshop tower and the market clocktower. Resonant tuning forks hang from the railings, singing whenever the bridge detects misaligned gears nearby.",
+      "exits": {
+        "e": "clocktower_belfry",
+        "w": "gearworks_mezzanine"
+      },
+      "items": [
+        {
+          "name": "Balancing Harness",
+          "description": "Strap it on to steady your footing while you work above the spinning gears."
+        }
+      ]
     },
     {
       "id": "cogspring",
       "title": "Cogspring Well",
-      "description": "A vertical fountain of gears trickles oil like water, powering hidden machines below.",
+      "description": "A vertical fountain of gears trickles oil like water, powering hidden machines below. Steam wisps carry the scent of ozone and hot iron.",
       "exits": {
         "d": "submerged_lab",
+        "e": "resonant_press",
         "w": "gearworks"
-      }
+      },
+      "items": [
+        {
+          "name": "Oilweave Cloth",
+          "description": "Wipe down any mechanism and the cloth records its last calibration settings."
+        }
+      ]
+    },
+    {
+      "id": "resonant_press",
+      "title": "Resonant Press",
+      "description": "Massive plates thrum with harmonic energy, imprinting circuits into clay with perfect precision. Each press stroke leaves a faint chord hanging in the air.",
+      "exits": {
+        "d": "pressure_lounge",
+        "s": "alloy_gallery",
+        "w": "cogspring"
+      },
+      "items": [
+        {
+          "name": "Tuning Die",
+          "description": "Slip the die into the press to change the frequency of the imprint it leaves behind."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Pressmaster Huun",
+          "auto_greet": "Keep your heartbeat steady—the press prefers calm partners."
+        }
+      ]
     },
     {
       "id": "submerged_lab",
       "title": "Submerged Laboratory",
-      "description": "Aquarium walls reveal experiments performed in bubbles, with fish wearing monocles taking notes.",
+      "description": "Aquarium walls reveal experiments performed in bubbles, with fish wearing monocles taking notes. Mechanical quills drift like seaweed, scribbling formulas in waterproof ink.",
       "exits": {
+        "s": "pressure_lounge",
         "u": "cogspring"
-      }
+      },
+      "items": [
+        {
+          "name": "Bubble Torch",
+          "description": "Ignite it underwater to cast a dry bubble around delicate equipment."
+        }
+      ]
+    },
+    {
+      "id": "pressure_lounge",
+      "title": "Pressure Lounge",
+      "description": "Padded alcoves provide respite for divers acclimating to different depths. Brass gauges glow softly as they equalize air and pressure for anyone emerging from the lower labs.",
+      "exits": {
+        "n": "submerged_lab",
+        "s": "ember_grotto",
+        "u": "resonant_press"
+      },
+      "items": [
+        {
+          "name": "Depth Bracelet",
+          "description": "Tiny runes adjust to your pulse, warning you when pressure changes too quickly."
+        }
+      ]
     },
     {
       "id": "forge",
       "title": "Volcanic Forge",
-      "description": "Anvils glow a gentle cherry red while sparks sketch blue afterimages in the air.",
+      "description": "Anvils glow a gentle cherry red while sparks sketch blue afterimages in the air. Automated bellows breathe in rhythm with a deep subterranean thrum.",
       "exits": {
-        "e": "smoke_garden",
+        "e": "alloy_gallery",
         "n": "heat_cradle",
+        "s": "inventors_forum",
         "w": "workshop"
-      }
+      },
+      "items": [
+        {
+          "name": "Molten Crucible",
+          "description": "The crucible remembers the melting point of any metal you pour within."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Forgewright Tessa",
+          "auto_greet": "Mind the sparks—they like curious pockets."
+        }
+      ]
     },
     {
       "id": "heat_cradle",
       "title": "Heat Cradle",
-      "description": "A suspended iron hammock radiates cozy warmth, perfect for incubating daring ideas.",
+      "description": "A suspended iron hammock radiates cozy warmth, perfect for incubating daring ideas. Racks of half-finished prototypes sway gently in the thermal currents.",
       "exits": {
+        "e": "slag_terrace",
         "s": "forge"
-      }
+      },
+      "items": [
+        {
+          "name": "Thermal Draft",
+          "description": "A scroll that releases a programmable wave of heat to temper delicate alloys."
+        }
+      ]
+    },
+    {
+      "id": "alloy_gallery",
+      "title": "Alloy Gallery",
+      "description": "Display cases showcase plates of experimental metals, each etched with their unique resonant frequency. Holographic annotations flicker above every sample.",
+      "exits": {
+        "e": "slag_terrace",
+        "n": "resonant_press",
+        "w": "forge"
+      },
+      "items": [
+        {
+          "name": "Alloy Ledger",
+          "description": "A ledger that records the blend of metals used in any item you examine here."
+        }
+      ]
+    },
+    {
+      "id": "slag_terrace",
+      "title": "Slag Terrace",
+      "description": "Molten slag pours in glittering ribbons into cooling troughs that sculpt themselves into bricks. The terrace overlooks the smoke garden below, its railings hot to the touch.",
+      "exits": {
+        "n": "heat_cradle",
+        "s": "smoke_garden",
+        "w": "alloy_gallery"
+      },
+      "items": [
+        {
+          "name": "Cooling Tongs",
+          "description": "These tongs hum softly when slag has cooled enough to handle safely."
+        }
+      ]
     },
     {
       "id": "smoke_garden",
       "title": "Smoke Garden",
-      "description": "Charcoal hedges puff scented rings that drift toward a cavern mouth below.",
+      "description": "Charcoal hedges puff scented rings that drift toward a cavern mouth below. Emberlit lanterns hang from iron trellises, forming constellations of workshop legends.",
       "exits": {
+        "n": "slag_terrace",
         "s": "ember_grotto",
         "w": "forge"
-      }
+      },
+      "items": [
+        {
+          "name": "Scented Char",
+          "description": "Crush it to release smoke that repels sparks from raw wood or cloth."
+        }
+      ]
     },
     {
       "id": "ember_grotto",
       "title": "Ember Grotto",
-      "description": "Ashen stalactites glow from within, breathing out embers that never quite touch the floor.",
+      "description": "Ashen stalactites glow from within, breathing out embers that never quite touch the floor. The air tastes faintly of spice and iron.",
       "exits": {
+        "e": "pressure_lounge",
         "n": "smoke_garden",
         "u": "root_caves"
-      }
+      },
+      "items": [
+        {
+          "name": "Smolder Stone",
+          "description": "A warm stone that reignites banked coals with a gentle squeeze."
+        }
+      ]
     },
     {
       "id": "atelier_dormitory",
       "title": "Atelier Dormitory",
-      "description": "Hammocks stitched from blueprints sway gently, each muttering half-finished inventions in its sleep.",
+      "description": "Hammocks stitched from blueprints sway gently, each muttering half-finished inventions in its sleep. Tool lockers double as nightstands, softly glowing when their owners dream of solutions.",
       "exits": {
         "e": "ink_garden",
         "n": "workshop",
+        "s": "prototype_gallery",
         "w": "lantern_row"
-      }
+      },
+      "items": [
+        {
+          "name": "Blueprint Blanket",
+          "description": "Wrap up in it and wake with a rough schematic of whatever you were puzzling over."
+        }
+      ]
+    },
+    {
+      "id": "prototype_gallery",
+      "title": "Prototype Gallery",
+      "description": "A hall of experimental devices spins slowly on suspended turntables. Each prototype projects a short demonstration when approached, eager for field testing.",
+      "exits": {
+        "e": "inventors_forum",
+        "n": "atelier_dormitory",
+        "w": "workshop"
+      },
+      "items": [
+        {
+          "name": "Trial Token",
+          "description": "Claiming a token grants temporary access to test any prototype in the gallery."
+        }
+      ]
+    },
+    {
+      "id": "inventors_forum",
+      "title": "Inventors' Forum",
+      "description": "Tiered seating surrounds a central dais where engineers pitch their boldest plans. Debate sigils flare gently, ensuring every voice is heard in orderly rotation.",
+      "exits": {
+        "n": "forge",
+        "s": "aerial_lab",
+        "w": "prototype_gallery"
+      },
+      "items": [
+        {
+          "name": "Debate Stylus",
+          "description": "Touch it to the dais and your idea becomes a shimmering schematic for all to inspect."
+        }
+      ],
+      "npcs": [
+        {
+          "name": "Moderator Fex",
+          "auto_greet": "Present your case succinctly—the queue of bright minds is never short."
+        }
+      ]
     },
     {
       "id": "loft",
       "title": "Windborne Loft",
-      "description": "Gauzy curtains billow inward, revealing a balcony stocked with spare wings and parachutes.",
+      "description": "Gauzy curtains billow inward, revealing a balcony stocked with spare wings and parachutes. Draft charts line the walls, mapping the safest glide paths between districts.",
       "exits": {
         "d": "workshop",
         "e": "wind_tunnel",
         "n": "balloon_roost"
-      }
+      },
+      "items": [
+        {
+          "name": "Glider Rig",
+          "description": "Folded canvas wings that deploy with a tug, perfect for short descents."
+        }
+      ]
     },
     {
       "id": "wind_tunnel",
       "title": "Wind Tuning Tunnel",
-      "description": "Pipes shift diameter with each step, harmonizing breezes into melodies of encouragement.",
+      "description": "Pipes shift diameter with each step, harmonizing breezes into melodies of encouragement. Panels along the wall slide open to test airflow on delicate inventions.",
       "exits": {
+        "e": "aerial_lab",
         "w": "loft"
-      }
+      },
+      "items": [
+        {
+          "name": "Resonant Vane",
+          "description": "Attach it to a prototype and it sings when airflow hits an optimal balance."
+        }
+      ]
+    },
+    {
+      "id": "aerial_lab",
+      "title": "Aerial Dynamics Lab",
+      "description": "Suspended platforms rise and fall on controlled gusts while tethered gliders practice delicate maneuvers. Charts of prevailing winds cascade down a central column.",
+      "exits": {
+        "n": "inventors_forum",
+        "w": "wind_tunnel"
+      },
+      "items": [
+        {
+          "name": "Stabilizer Ribbon",
+          "description": "Tie it to a wing edge to automatically counterbalance turbulence."
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- expand the central convergence with new traversal options, rooms, and ambient storytelling objects
- enrich the garden, library, market, and workshop districts with additional rooms, items, and NPC guides to make exploration feel vast and detailed
- connect the new aurora balcony to the observatory signal gallery to weave the hub and celestial complex together

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d718fb1944832a99d02f2d077758b1