### PR TITLE
Add CLI flags for customizable data storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ To listen on a different host or port, supply the `-addr` flag. For example, to 
 go run . -addr "127.0.0.1:5000"
 ```
 
+Player data defaults to the files under [`data/`](data/). Use `-accounts` to choose a different account database and `-areas` to load world definitions from another directory:
+
+```bash
+go run . -accounts /var/lumen/accounts.json -areas /opt/world-data
+```
+
+When overriding the accounts file, persistent mail and offline tells automatically live beside it (for example `/var/lumen/mail.json` and `/var/lumen/tells.json`). You can point each of these stores elsewhere with `-mail` and `-tells` if desired:
+
+```bash
+go run . -accounts /var/lumen/accounts.json -mail /srv/mailbox.json -tells /srv/tells.json
+```
+
 Enable TLS by passing `-tls`. By default the server stores its certificate at `data/tls/cert.pem` and private key at `data/tls/key.pem`,
 and you can override these paths with the `-cert` and `-key` flags:
 

--- a/internal/game/server_test.go
+++ b/internal/game/server_test.go
@@ -1,0 +1,225 @@
+package game
+
+import (
+	"crypto/tls"
+	"errors"
+	"net"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+type stubListener struct {
+	addr      net.Addr
+	acceptErr error
+	closed    bool
+	mu        sync.Mutex
+}
+
+func (s *stubListener) Accept() (net.Conn, error) {
+	return nil, s.acceptErr
+}
+
+func (s *stubListener) Close() error {
+	s.mu.Lock()
+	s.closed = true
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *stubListener) Addr() net.Addr {
+	return s.addr
+}
+
+func TestListenAndServeOverridesStoragePaths(t *testing.T) {
+	dir := t.TempDir()
+	accountsPath := filepath.Join(dir, "config", "accounts.json")
+	areasPath := filepath.Join(dir, "areas")
+	mailOverride := filepath.Join(dir, "mailbox.json")
+	tellsOverride := filepath.Join(dir, "whispers.json")
+
+	sentinel := errors.New("stub listener failure")
+	listener := &stubListener{addr: &net.TCPAddr{}, acceptErr: sentinel}
+
+	captured := struct {
+		mail  string
+		tells string
+	}{}
+
+	originalMailFactory := mailSystemFactory
+	originalTellFactory := tellSystemFactory
+	originalWorldFactory := worldFactory
+	originalNetListen := netListenFunc
+	defer func() {
+		mailSystemFactory = originalMailFactory
+		tellSystemFactory = originalTellFactory
+		worldFactory = originalWorldFactory
+		netListenFunc = originalNetListen
+	}()
+
+	mailSystemFactory = func(path string) (*MailSystem, error) {
+		captured.mail = path
+		return &MailSystem{path: path, nextID: 1, boards: make(map[string][]MailMessage)}, nil
+	}
+	tellSystemFactory = func(path string) (*TellSystem, error) {
+		captured.tells = path
+		return &TellSystem{path: path, queue: make(map[string][]OfflineTell)}, nil
+	}
+	worldFactory = func(string) (*World, error) {
+		return NewWorldWithRooms(map[RoomID]*Room{StartRoom: {ID: StartRoom}}), nil
+	}
+	netListenFunc = func(string, string) (net.Listener, error) {
+		return listener, nil
+	}
+
+	err := ListenAndServe(
+		"127.0.0.1:0",
+		accountsPath,
+		areasPath,
+		"admin",
+		func(*World, *Player, string) bool { return false },
+		false,
+		WithMailPath(mailOverride),
+		WithTellPath(tellsOverride),
+	)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("ListenAndServe error = %v, want %v", err, sentinel)
+	}
+	if captured.mail != mailOverride {
+		t.Fatalf("mail path = %q, want %q", captured.mail, mailOverride)
+	}
+	if captured.tells != tellsOverride {
+		t.Fatalf("tells path = %q, want %q", captured.tells, tellsOverride)
+	}
+}
+
+func TestListenAndServeDerivesStoragePathsFromAccounts(t *testing.T) {
+	dir := t.TempDir()
+	accountsPath := filepath.Join(dir, "state", "users.db")
+	areasPath := filepath.Join(dir, "areas")
+	expectedMail := filepath.Join(dir, "state", "mail.json")
+	expectedTells := filepath.Join(dir, "state", "tells.json")
+
+	sentinel := errors.New("stub listener failure")
+	listener := &stubListener{addr: &net.TCPAddr{}, acceptErr: sentinel}
+
+	captured := struct {
+		mail  string
+		tells string
+	}{}
+
+	originalMailFactory := mailSystemFactory
+	originalTellFactory := tellSystemFactory
+	originalWorldFactory := worldFactory
+	originalNetListen := netListenFunc
+	defer func() {
+		mailSystemFactory = originalMailFactory
+		tellSystemFactory = originalTellFactory
+		worldFactory = originalWorldFactory
+		netListenFunc = originalNetListen
+	}()
+
+	mailSystemFactory = func(path string) (*MailSystem, error) {
+		captured.mail = path
+		return &MailSystem{path: path, nextID: 1, boards: make(map[string][]MailMessage)}, nil
+	}
+	tellSystemFactory = func(path string) (*TellSystem, error) {
+		captured.tells = path
+		return &TellSystem{path: path, queue: make(map[string][]OfflineTell)}, nil
+	}
+	worldFactory = func(string) (*World, error) {
+		return NewWorldWithRooms(map[RoomID]*Room{StartRoom: {ID: StartRoom}}), nil
+	}
+	netListenFunc = func(string, string) (net.Listener, error) {
+		return listener, nil
+	}
+
+	err := ListenAndServe(
+		"127.0.0.1:0",
+		accountsPath,
+		areasPath,
+		"admin",
+		func(*World, *Player, string) bool { return false },
+		false,
+	)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("ListenAndServe error = %v, want %v", err, sentinel)
+	}
+	if captured.mail != expectedMail {
+		t.Fatalf("mail path = %q, want %q", captured.mail, expectedMail)
+	}
+	if captured.tells != expectedTells {
+		t.Fatalf("tells path = %q, want %q", captured.tells, expectedTells)
+	}
+}
+
+func TestListenAndServeTLSAppliesStorageOverrides(t *testing.T) {
+	dir := t.TempDir()
+	accountsPath := filepath.Join(dir, "accounts.json")
+	areasPath := filepath.Join(dir, "areas")
+	certFile := filepath.Join(dir, "cert.pem")
+	keyFile := filepath.Join(dir, "key.pem")
+	mailOverride := filepath.Join(dir, "mail.json")
+	tellsOverride := filepath.Join(dir, "tells.json")
+
+	sentinel := errors.New("stub listener failure")
+	listener := &stubListener{addr: &net.TCPAddr{}, acceptErr: sentinel}
+
+	captured := struct {
+		mail  string
+		tells string
+	}{}
+
+	originalMailFactory := mailSystemFactory
+	originalTellFactory := tellSystemFactory
+	originalWorldFactory := worldFactory
+	originalTLSListen := tlsListenFunc
+	originalEnsureCert := ensureCertificateFunc
+	defer func() {
+		mailSystemFactory = originalMailFactory
+		tellSystemFactory = originalTellFactory
+		worldFactory = originalWorldFactory
+		tlsListenFunc = originalTLSListen
+		ensureCertificateFunc = originalEnsureCert
+	}()
+
+	mailSystemFactory = func(path string) (*MailSystem, error) {
+		captured.mail = path
+		return &MailSystem{path: path, nextID: 1, boards: make(map[string][]MailMessage)}, nil
+	}
+	tellSystemFactory = func(path string) (*TellSystem, error) {
+		captured.tells = path
+		return &TellSystem{path: path, queue: make(map[string][]OfflineTell)}, nil
+	}
+	worldFactory = func(string) (*World, error) {
+		return NewWorldWithRooms(map[RoomID]*Room{StartRoom: {ID: StartRoom}}), nil
+	}
+	tlsListenFunc = func(string, string, *tls.Config) (net.Listener, error) {
+		return listener, nil
+	}
+	ensureCertificateFunc = func(string, string, string) (tls.Certificate, bool, error) {
+		return tls.Certificate{}, false, nil
+	}
+
+	err := ListenAndServeTLS(
+		"127.0.0.1:0",
+		accountsPath,
+		areasPath,
+		certFile,
+		keyFile,
+		"admin",
+		func(*World, *Player, string) bool { return false },
+		false,
+		WithMailPath(mailOverride),
+		WithTellPath(tellsOverride),
+	)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("ListenAndServeTLS error = %v, want %v", err, sentinel)
+	}
+	if captured.mail != mailOverride {
+		t.Fatalf("mail path = %q, want %q", captured.mail, mailOverride)
+	}
+	if captured.tells != tellsOverride {
+		t.Fatalf("tells path = %q, want %q", captured.tells, tellsOverride)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"log"
+	"strings"
 
 	"LumenClay/commands"
 	"LumenClay/internal/game"
@@ -15,13 +16,25 @@ func main() {
 	keyFile := flag.String("key", "data/tls/key.pem", "Path to the TLS private key file")
 	adminAccount := flag.String("admin", "admin", "Account granted administrator privileges")
 	everyoneAdmin := flag.Bool("everyone-admin", false, "Grant administrator privileges to all players while disabling reboot and shutdown commands")
+	accountsPath := flag.String("accounts", "data/accounts.json", "Path to the player accounts database")
+	areasPath := flag.String("areas", game.DefaultAreasPath, "Directory containing world area definitions")
+	mailPath := flag.String("mail", "", "Optional path to persistent mail storage (defaults beside the accounts file)")
+	tellsPath := flag.String("tells", "", "Optional path to offline tells storage (defaults beside the accounts file)")
 	flag.Parse()
+
+	var options []game.ServerOption
+	if trimmed := strings.TrimSpace(*mailPath); trimmed != "" {
+		options = append(options, game.WithMailPath(trimmed))
+	}
+	if trimmed := strings.TrimSpace(*tellsPath); trimmed != "" {
+		options = append(options, game.WithTellPath(trimmed))
+	}
 
 	var err error
 	if *useTLS {
-		err = game.ListenAndServeTLS(*addr, "data/accounts.json", game.DefaultAreasPath, *certFile, *keyFile, *adminAccount, commands.Dispatch, *everyoneAdmin)
+		err = game.ListenAndServeTLS(*addr, *accountsPath, *areasPath, *certFile, *keyFile, *adminAccount, commands.Dispatch, *everyoneAdmin, options...)
 	} else {
-		err = game.ListenAndServe(*addr, "data/accounts.json", game.DefaultAreasPath, *adminAccount, commands.Dispatch, *everyoneAdmin)
+		err = game.ListenAndServe(*addr, *accountsPath, *areasPath, *adminAccount, commands.Dispatch, *everyoneAdmin, options...)
 	}
 
 	if err != nil {


### PR DESCRIPTION
## Summary
- add CLI flags to configure account, area, mail, and tell storage paths and forward them into the game server
- extend the server with configurable storage options and dependency injection hooks used by new tests
- document the new flags and cover both default and custom storage path handling with unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d843bdd33c832aa30bb098621210ed