### PR TITLE
Add retention policy to tell system

### DIFF
--- a/internal/game/tell_test.go
+++ b/internal/game/tell_test.go
@@ -1,8 +1,10 @@
 package game
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -70,5 +72,104 @@ func TestTellSystemEnforcesPerSenderLimit(t *testing.T) {
 	}
 	if _, err := system.Queue("Another", "Recipient", "Allowed", time.Time{}); err != nil {
 		t.Fatalf("Queue from different sender: %v", err)
+	}
+}
+
+func TestTellSystemRetentionPrunesOnLoad(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tells.json")
+	now := time.Now().UTC()
+	payload := struct {
+		Queue map[string][]OfflineTell `json:"queue"`
+	}{Queue: map[string][]OfflineTell{
+		"Bob": {
+			{Sender: "Alice", Recipient: "Bob", Body: "Too old", CreatedAt: now.Add(-2 * time.Hour)},
+			{Sender: "Charlie", Recipient: "Bob", Body: "Keep 1", CreatedAt: now.Add(-30 * time.Minute)},
+			{Sender: "Dana", Recipient: "Bob", Body: "Keep 2", CreatedAt: now.Add(-10 * time.Minute)},
+		},
+	}}
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create tells file: %v", err)
+	}
+	if err := json.NewEncoder(file).Encode(payload); err != nil {
+		t.Fatalf("encode tells: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close tells file: %v", err)
+	}
+
+	policy := TellRetentionPolicy{MaxAge: time.Hour, MaxMessagesPerRecipient: 2}
+	system, err := NewTellSystemWithRetention(path, policy)
+	if err != nil {
+		t.Fatalf("NewTellSystemWithRetention: %v", err)
+	}
+	pending := system.PendingFor("Bob")
+	if len(pending) != 2 {
+		t.Fatalf("PendingFor returned %d entries, want 2", len(pending))
+	}
+	if pending[0].Body != "Keep 1" || pending[1].Body != "Keep 2" {
+		t.Fatalf("PendingFor returned unexpected messages: %#v", pending)
+	}
+}
+
+func TestTellSystemRetentionPrunesOnQueue(t *testing.T) {
+	policy := TellRetentionPolicy{MaxAge: 10 * time.Millisecond, MaxMessagesPerRecipient: 2}
+	system, err := NewTellSystemWithRetention("", policy)
+	if err != nil {
+		t.Fatalf("NewTellSystemWithRetention: %v", err)
+	}
+	if _, err := system.Queue("Alice", "Bob", "First", time.Time{}); err != nil {
+		t.Fatalf("Queue first: %v", err)
+	}
+	// Ensure the first entry exceeds the retention age.
+	time.Sleep(20 * time.Millisecond)
+	if _, err := system.Queue("Charlie", "Bob", "Second", time.Time{}); err != nil {
+		t.Fatalf("Queue second: %v", err)
+	}
+	pending := system.PendingFor("Bob")
+	if len(pending) != 1 || pending[0].Body != "Second" {
+		t.Fatalf("PendingFor after second queue incorrect: %#v", pending)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+	if _, err := system.Queue("Dana", "Bob", "Third", time.Time{}); err != nil {
+		t.Fatalf("Queue third: %v", err)
+	}
+	pending = system.PendingFor("Bob")
+	if len(pending) != 1 || pending[0].Body != "Third" {
+		t.Fatalf("PendingFor after third queue incorrect: %#v", pending)
+	}
+}
+
+func TestTellSystemRetentionPersistsPrunedEntries(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tells.json")
+	policy := TellRetentionPolicy{MaxMessagesPerRecipient: 2}
+	system, err := NewTellSystemWithRetention(path, policy)
+	if err != nil {
+		t.Fatalf("NewTellSystemWithRetention: %v", err)
+	}
+	base := time.Date(2025, time.January, 1, 12, 0, 0, 0, time.UTC)
+	if _, err := system.Queue("Alice", "Bob", "First", base); err != nil {
+		t.Fatalf("Queue first: %v", err)
+	}
+	if _, err := system.Queue("Charlie", "Bob", "Second", base.Add(time.Minute)); err != nil {
+		t.Fatalf("Queue second: %v", err)
+	}
+	if _, err := system.Queue("Dana", "Bob", "Third", base.Add(2*time.Minute)); err != nil {
+		t.Fatalf("Queue third: %v", err)
+	}
+
+	reloaded, err := NewTellSystemWithRetention(path, policy)
+	if err != nil {
+		t.Fatalf("Reload TellSystemWithRetention: %v", err)
+	}
+	pending := reloaded.PendingFor("Bob")
+	if len(pending) != 2 {
+		t.Fatalf("Reloaded pending count = %d, want 2", len(pending))
+	}
+	if pending[0].Body != "Second" || pending[1].Body != "Third" {
+		t.Fatalf("Reloaded pending unexpected: %#v", pending)
 	}
 }


### PR DESCRIPTION
## Summary
- add a configurable retention policy to the offline tell system
- prune expired or excess tells when loading, queuing, and persisting
- cover the retention behaviour with new tests, including persistence pruning

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d843b74914832aaa6e030e03284238