### PR TITLE
Add HTTPS staff portal with single-use links

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ After logging in, type `help` (or `?`) to see the in-game reference. Common comm
 - `quit` &mdash; Disconnect from the server.
 - `reboot` (admin only) &mdash; Reload the world data and return everyone to the starting room.
 - `buildhelp` (builders/admins) &mdash; List the online creation commands available to builders.
+- `portal [builder|moderator|admin]` (builders/moderators/admins) &mdash; Generate a one-use HTTPS link to the staff web portal.
 - `wizhelp` (admin only) &mdash; List administrative commands such as `reboot` and `summon`.
 
 Climb to the Glazemaker's Overlook from the starting atrium and head north to reach the new Celestial Observatory. There you'll find the Horizon Plaza, Zephyr Rampart, Astral Scriptorium, and the Lenswright Workshop, now joined by the Arcade of Shifting Sundials, a noctilucent reflecting pool, and an expanded vertical circuit that threads through the Aurora Spire, its heliograph gallery, a chart vault walkway, and the tea-scented loft of Professor Orrin before cresting at the beaconry. The subterranean Starwell, Resonance Vault, and Gravity Underchamber remain below, rounding out a sky-struck ascent packed with NPCs and artifacts.

--- a/commands/moderator.go
+++ b/commands/moderator.go
@@ -1,0 +1,53 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"LumenClay/internal/game"
+)
+
+var Moderator = Define(Definition{
+	Name:        "moderator",
+	Usage:       "moderator <player> <on|off>",
+	Description: "grant or revoke moderator rights (admin only)",
+	Group:       GroupAdmin,
+}, func(ctx *Context) bool {
+	if !ctx.Player.IsAdmin {
+		ctx.Player.Output <- game.Ansi(game.Style("\r\nOnly admins may manage moderators.", game.AnsiYellow))
+		return false
+	}
+	parts := strings.Fields(ctx.Arg)
+	if len(parts) != 2 {
+		ctx.Player.Output <- game.Ansi(game.Style("\r\nUsage: moderator <player> <on|off>", game.AnsiYellow))
+		return false
+	}
+	targetName := parts[0]
+	toggle := strings.ToLower(parts[1])
+	var enable bool
+	switch toggle {
+	case "on", "enable", "enabled", "true", "grant":
+		enable = true
+	case "off", "disable", "disabled", "false", "revoke":
+		enable = false
+	default:
+		ctx.Player.Output <- game.Ansi(game.Style("\r\nUsage: moderator <player> <on|off>", game.AnsiYellow))
+		return false
+	}
+	target, err := ctx.World.SetModerator(targetName, enable)
+	if err != nil {
+		ctx.Player.Output <- game.Ansi(game.Style("\r\n"+err.Error(), game.AnsiYellow))
+		return false
+	}
+	state := "no longer"
+	if enable {
+		state = "now"
+	}
+	ctx.Player.Output <- game.Ansi(fmt.Sprintf("\r\n%s is %s a moderator.", game.HighlightName(target.Name), state))
+	notice := "\r\nYou are now a moderator."
+	if !enable {
+		notice = "\r\nYou are no longer a moderator."
+	}
+	target.Output <- game.Ansi(notice)
+	return false
+})

--- a/commands/portal.go
+++ b/commands/portal.go
@@ -1,0 +1,118 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"LumenClay/internal/game"
+)
+
+var Portal = Define(Definition{
+	Name:        "portal",
+	Usage:       "portal [builder|moderator|admin]",
+	Description: "generate a secure one-use web portal link",
+	Group:       GroupBuilder,
+}, func(ctx *Context) bool {
+	provider := ctx.World.Portal()
+	if provider == nil {
+		ctx.Player.Output <- game.Ansi(game.Style("\r\nThe web portal is not configured.", game.AnsiYellow))
+		return false
+	}
+
+	requested := strings.ToLower(strings.TrimSpace(ctx.Arg))
+	role, ok := selectPortalRole(ctx.Player, requested)
+	if !ok {
+		if requested != "" {
+			ctx.Player.Output <- game.Ansi(game.Style("\r\nYou are not permitted to request that portal.", game.AnsiYellow))
+		} else {
+			ctx.Player.Output <- game.Ansi(game.Style("\r\nOnly builders, moderators, or admins may request portal links.", game.AnsiYellow))
+		}
+		return false
+	}
+
+	link, err := provider.GenerateLink(role, ctx.Player.Name)
+	if err != nil {
+		ctx.Player.Output <- game.Ansi(game.Style("\r\nFailed to generate portal link: "+err.Error(), game.AnsiYellow))
+		return false
+	}
+
+	ttl := time.Until(link.Expires)
+	if ttl < 0 {
+		ttl = 0
+	}
+	ttlText := formatPortalDuration(ttl)
+	label := portalRoleLabel(role)
+	hyperlink := game.Hyperlink(link.URL, "Open portal")
+	message := fmt.Sprintf("\r\n%s portal link (expires in %s): %s\r\n  %s", label, ttlText, hyperlink, link.URL)
+	ctx.Player.Output <- game.Ansi(message)
+	ctx.Player.Output <- game.Ansi(game.Style("\r\nThe link may be used once. Request a new one if it expires.", game.AnsiYellow))
+	return false
+})
+
+func selectPortalRole(player *game.Player, requested string) (game.PortalRole, bool) {
+	switch requested {
+	case "builder":
+		if player.IsBuilder || player.IsAdmin || player.IsModerator {
+			return game.PortalRoleBuilder, true
+		}
+		return "", false
+	case "moderator":
+		if player.IsAdmin || player.IsModerator {
+			return game.PortalRoleModerator, true
+		}
+		return "", false
+	case "admin":
+		if player.IsAdmin {
+			return game.PortalRoleAdmin, true
+		}
+		return "", false
+	case "":
+		switch {
+		case player.IsAdmin:
+			return game.PortalRoleAdmin, true
+		case player.IsModerator:
+			return game.PortalRoleModerator, true
+		case player.IsBuilder:
+			return game.PortalRoleBuilder, true
+		default:
+			return "", false
+		}
+	default:
+		return "", false
+	}
+}
+
+func portalRoleLabel(role game.PortalRole) string {
+	switch role {
+	case game.PortalRoleAdmin:
+		return "Administration"
+	case game.PortalRoleModerator:
+		return "Moderation"
+	default:
+		return "Builder"
+	}
+}
+
+func formatPortalDuration(d time.Duration) string {
+	if d <= 0 {
+		return "0s"
+	}
+	d = d.Round(time.Second)
+	hours := d / time.Hour
+	d -= hours * time.Hour
+	minutes := d / time.Minute
+	d -= minutes * time.Minute
+	seconds := d / time.Second
+	parts := make([]string, 0, 3)
+	if hours > 0 {
+		parts = append(parts, fmt.Sprintf("%dh", hours))
+	}
+	if minutes > 0 {
+		parts = append(parts, fmt.Sprintf("%dm", minutes))
+	}
+	if seconds > 0 || len(parts) == 0 {
+		parts = append(parts, fmt.Sprintf("%ds", seconds))
+	}
+	return strings.Join(parts, " ")
+}

--- a/commands/portal_test.go
+++ b/commands/portal_test.go
@@ -1,0 +1,64 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"LumenClay/internal/game"
+)
+
+type fakePortal struct {
+	url      string
+	expires  time.Time
+	lastRole game.PortalRole
+	err      error
+}
+
+func (f *fakePortal) GenerateLink(role game.PortalRole, player string) (game.PortalLink, error) {
+	f.lastRole = role
+	if f.err != nil {
+		return game.PortalLink{}, f.err
+	}
+	return game.PortalLink{URL: f.url, Expires: f.expires, Role: role}, nil
+}
+
+func TestPortalCommandRequiresPortal(t *testing.T) {
+	world := game.NewWorldWithRooms(map[game.RoomID]*game.Room{
+		"start": {ID: "start", Title: "Start", Description: "", Exits: map[string]game.RoomID{}},
+	})
+	builder := newTestPlayer("Builder", "start")
+	builder.IsBuilder = true
+	world.AddPlayerForTest(builder)
+
+	if quit := Dispatch(world, builder, "portal"); quit {
+		t.Fatalf("dispatch returned true, want false")
+	}
+	output := strings.Join(drainOutput(builder.Output), "\n")
+	if !strings.Contains(output, "web portal is not configured") {
+		t.Fatalf("expected configuration warning, got %q", output)
+	}
+}
+
+func TestPortalCommandGeneratesLink(t *testing.T) {
+	world := game.NewWorldWithRooms(map[game.RoomID]*game.Room{
+		"start": {ID: "start", Title: "Start", Description: "", Exits: map[string]game.RoomID{}},
+	})
+	admin := newTestPlayer("Admin", "start")
+	admin.IsAdmin = true
+	world.AddPlayerForTest(admin)
+
+	fake := &fakePortal{url: "https://example.com/portal/token", expires: time.Now().Add(2 * time.Minute)}
+	world.AttachPortal(fake)
+
+	if quit := Dispatch(world, admin, "portal moderator"); quit {
+		t.Fatalf("dispatch returned true, want false")
+	}
+	msgs := strings.Join(drainOutput(admin.Output), "\n")
+	if !strings.Contains(msgs, "Open portal") || !strings.Contains(msgs, fake.url) {
+		t.Fatalf("expected portal link in output, got %q", msgs)
+	}
+	if fake.lastRole != game.PortalRoleModerator {
+		t.Fatalf("portal requested role %q, want %q", fake.lastRole, game.PortalRoleModerator)
+	}
+}

--- a/commands/stats.go
+++ b/commands/stats.go
@@ -140,6 +140,9 @@ func formatRoles(player *game.Player) string {
 	if player.IsBuilder {
 		roles = append(roles, "Builder")
 	}
+	if player.IsModerator {
+		roles = append(roles, "Moderator")
+	}
 	if player.IsAdmin {
 		roles = append(roles, "Admin")
 	}
@@ -148,6 +151,8 @@ func formatRoles(player *game.Player) string {
 		switch role {
 		case "Admin":
 			styled[i] = game.Style(role, game.AnsiBold, game.AnsiMagenta)
+		case "Moderator":
+			styled[i] = game.Style(role, game.AnsiBold, game.AnsiBlue)
 		case "Builder":
 			styled[i] = game.Style(role, game.AnsiCyan)
 		default:

--- a/internal/game/ansi.go
+++ b/internal/game/ansi.go
@@ -55,6 +55,22 @@ func HighlightQuestName(name string) string {
 	return Style(name, AnsiBold, AnsiBlue)
 }
 
+// Hyperlink wraps text in an OSC 8 escape sequence for supported clients.
+func Hyperlink(url, label string) string {
+	trimmed := strings.TrimSpace(url)
+	if trimmed == "" {
+		if label == "" {
+			return ""
+		}
+		return label
+	}
+	safe := strings.ReplaceAll(trimmed, "\x1b", "")
+	if label == "" {
+		label = safe
+	}
+	return fmt.Sprintf("\x1b]8;;%s\x1b\\%s\x1b]8;;\x1b\\", safe, label)
+}
+
 // Trim normalises a telnet input line.
 func Trim(s string) string {
 	cleaned := sanitizeInput(s)

--- a/internal/game/player.go
+++ b/internal/game/player.go
@@ -16,6 +16,7 @@ type Player struct {
 	Output           chan string
 	Alive            bool
 	IsAdmin          bool
+	IsModerator      bool
 	IsBuilder        bool
 	Channels         map[Channel]bool
 	ChannelAliases   map[Channel]string

--- a/internal/game/portal.go
+++ b/internal/game/portal.go
@@ -1,0 +1,615 @@
+package game
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/tls"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// PortalRole identifies the interface exposed by the web portal.
+//
+// (stringer directive left for potential tooling; generation not required.)
+//
+//go:generate stringer -type=PortalRole -linecomment
+type PortalRole string
+
+const (
+	// PortalRoleBuilder grants access to the building dashboard.
+	PortalRoleBuilder PortalRole = "builder"
+	// PortalRoleModerator grants access to moderation tooling.
+	PortalRoleModerator PortalRole = "moderator"
+	// PortalRoleAdmin grants access to privileged administration views.
+	PortalRoleAdmin PortalRole = "admin"
+)
+
+// PortalLink bundles the generated URL with its expiry.
+type PortalLink struct {
+	URL     string
+	Expires time.Time
+	Role    PortalRole
+}
+
+// PortalProvider issues web links for privileged interfaces.
+type PortalProvider interface {
+	GenerateLink(role PortalRole, player string) (PortalLink, error)
+}
+
+// PortalConfig captures the listener and TLS configuration for the web portal.
+type PortalConfig struct {
+	Addr       string
+	BaseURL    string
+	CertFile   string
+	KeyFile    string
+	TokenTTL   time.Duration
+	SessionTTL time.Duration
+}
+
+var portalFactory = newPortalServer
+
+const (
+	portalTokenBytes     = 24
+	portalSessionBytes   = 24
+	portalDefaultToken   = 5 * time.Minute
+	portalDefaultSession = 30 * time.Minute
+	portalCookieName     = "lc_portal"
+)
+
+type portalToken struct {
+	Role    PortalRole
+	Player  string
+	Expires time.Time
+}
+
+type portalSession struct {
+	Role    PortalRole
+	Player  string
+	Expires time.Time
+}
+
+// PortalServer hosts the HTTPS staff interface and manages short-lived tokens.
+type PortalServer struct {
+	world      *World
+	baseURL    string
+	tokenTTL   time.Duration
+	sessionTTL time.Duration
+
+	mu       sync.Mutex
+	tokens   map[string]portalToken
+	sessions map[string]portalSession
+
+	server   *http.Server
+	listener net.Listener
+	ready    chan struct{}
+}
+
+func newPortalServer(world *World, cfg PortalConfig) (PortalProvider, error) {
+	if world == nil {
+		return nil, fmt.Errorf("portal requires world reference")
+	}
+	addr := strings.TrimSpace(cfg.Addr)
+	if addr == "" {
+		return nil, nil
+	}
+	tokenTTL := cfg.TokenTTL
+	if tokenTTL <= 0 {
+		tokenTTL = portalDefaultToken
+	}
+	sessionTTL := cfg.SessionTTL
+	if sessionTTL <= 0 {
+		sessionTTL = portalDefaultSession
+	}
+	certFile := strings.TrimSpace(cfg.CertFile)
+	keyFile := strings.TrimSpace(cfg.KeyFile)
+	if certFile == "" || keyFile == "" {
+		return nil, fmt.Errorf("portal requires certificate and key paths")
+	}
+
+	cert, created, err := ensureCertificateFunc(certFile, keyFile, addr)
+	if err != nil {
+		return nil, err
+	}
+	if created {
+		fmt.Printf("Generated self-signed TLS certificate for web portal at %s and %s\n", certFile, keyFile)
+	}
+	tlsConfig := &tls.Config{Certificates: []tls.Certificate{cert}}
+	listener, err := tlsListenFunc("tcp", addr, tlsConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	actualAddr := listener.Addr().String()
+	baseURL := strings.TrimSpace(cfg.BaseURL)
+	if baseURL == "" {
+		baseURL = derivePortalBaseURL(actualAddr)
+	}
+	if baseURL == "" {
+		listener.Close()
+		return nil, fmt.Errorf("unable to determine base URL for portal; specify web-base-url")
+	}
+
+	server := &http.Server{}
+	portal := &PortalServer{
+		world:      world,
+		baseURL:    baseURL,
+		tokenTTL:   tokenTTL,
+		sessionTTL: sessionTTL,
+		tokens:     make(map[string]portalToken),
+		sessions:   make(map[string]portalSession),
+		server:     server,
+		listener:   listener,
+		ready:      make(chan struct{}),
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", portal.handleRoot)
+	mux.HandleFunc("/portal/", portal.handleToken)
+	mux.HandleFunc("/interface", portal.handleInterface)
+	mux.HandleFunc("/api/players", portal.handlePlayersAPI)
+	server.Handler = portal.addSecurityHeaders(mux)
+
+	go func() {
+		close(portal.ready)
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			fmt.Printf("Web portal error: %v\n", err)
+		}
+	}()
+
+	fmt.Printf("Web portal listening on %s\n", baseURL)
+	return portal, nil
+}
+
+func derivePortalBaseURL(addr string) string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return ""
+	}
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = "localhost"
+	}
+	if strings.Contains(host, ":") && !strings.HasPrefix(host, "[") {
+		host = "[" + host + "]"
+	}
+	if port == "443" {
+		return fmt.Sprintf("https://%s", host)
+	}
+	return fmt.Sprintf("https://%s:%s", host, port)
+}
+
+func (p *PortalServer) BaseURL() string {
+	if p == nil {
+		return ""
+	}
+	return p.baseURL
+}
+
+// WaitReady blocks until the server goroutine has started listening.
+func (p *PortalServer) WaitReady(ctx context.Context) error {
+	if p == nil {
+		return nil
+	}
+	select {
+	case <-p.ready:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Close gracefully stops the HTTPS server.
+func (p *PortalServer) Close() error {
+	if p == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	return p.server.Shutdown(ctx)
+}
+
+func (p *PortalServer) addSecurityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Strict-Transport-Security", "max-age=31536000")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("Referrer-Policy", "no-referrer")
+		w.Header().Set("Content-Security-Policy", "default-src 'self'; style-src 'self' 'unsafe-inline'")
+		next.ServeHTTP(w, r)
+	})
+}
+
+// GenerateLink returns a one-use URL that grants access to the requested role.
+func (p *PortalServer) GenerateLink(role PortalRole, player string) (PortalLink, error) {
+	if p == nil {
+		return PortalLink{}, fmt.Errorf("portal is not configured")
+	}
+	if !isSupportedPortalRole(role) {
+		return PortalLink{}, fmt.Errorf("unsupported portal role: %s", role)
+	}
+	token, err := randomToken(portalTokenBytes)
+	if err != nil {
+		return PortalLink{}, err
+	}
+	now := time.Now()
+	expires := now.Add(p.tokenTTL)
+	trimmedURL := strings.TrimRight(p.baseURL, "/")
+	p.mu.Lock()
+	p.purgeExpiredLocked(now)
+	p.tokens[token] = portalToken{Role: role, Player: player, Expires: expires}
+	p.mu.Unlock()
+	return PortalLink{URL: fmt.Sprintf("%s/portal/%s", trimmedURL, token), Expires: expires, Role: role}, nil
+}
+
+func (p *PortalServer) handleRoot(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if session, id, ok := p.sessionForRequest(r); ok {
+		p.setSessionCookie(w, id, session.Expires)
+		http.Redirect(w, r, "/interface", http.StatusSeeOther)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write([]byte("<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>LumenClay Portal</title></head><body><main><h1>LumenClay Portal</h1><p>This link has expired or is invalid. Request a new portal link from within the game.</p></main></body></html>"))
+}
+
+func (p *PortalServer) handleToken(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	token := strings.TrimPrefix(r.URL.Path, "/portal/")
+	token = strings.TrimSpace(token)
+	if token == "" {
+		http.NotFound(w, r)
+		return
+	}
+	payload, ok := p.consumeToken(token)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	id, session, err := p.createSession(payload.Role, payload.Player)
+	if err != nil {
+		http.Error(w, "unable to create session", http.StatusInternalServerError)
+		return
+	}
+	p.setSessionCookie(w, id, session.Expires)
+	http.Redirect(w, r, "/interface", http.StatusSeeOther)
+}
+
+func (p *PortalServer) handleInterface(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	session, id, ok := p.sessionForRequest(r)
+	if !ok {
+		http.Redirect(w, r, "/", http.StatusSeeOther)
+		return
+	}
+	p.setSessionCookie(w, id, session.Expires)
+	snapshots := p.world.PlayerSnapshots()
+	views := make([]portalPlayerView, 0, len(snapshots))
+	for _, snap := range snapshots {
+		view := portalPlayerView{
+			Name:     snap.Name,
+			Location: snap.RoomTitle,
+			RoomID:   string(snap.Room),
+			Roles:    playerRolesForSnapshot(snap),
+		}
+		if strings.TrimSpace(view.Location) == "" {
+			view.Location = view.RoomID
+		}
+		views = append(views, view)
+	}
+	dataBytes, _ := json.Marshal(views)
+	now := time.Now()
+	tplData := portalPageData{
+		Player:          session.Player,
+		Role:            session.Role,
+		RoleTitle:       portalRoleTitle(session.Role),
+		RoleDescription: portalRoleDescription(session.Role),
+		Generated:       now.Format(time.RFC1123),
+		SessionExpiry:   session.Expires.Format(time.RFC1123),
+		Players:         views,
+		PlayersJSON:     template.JS(dataBytes),
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := portalTemplate.Execute(w, tplData); err != nil {
+		http.Error(w, "render error", http.StatusInternalServerError)
+	}
+}
+
+func (p *PortalServer) handlePlayersAPI(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	session, id, ok := p.sessionForRequest(r)
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	p.setSessionCookie(w, id, session.Expires)
+	snapshots := p.world.PlayerSnapshots()
+	views := make([]portalPlayerView, 0, len(snapshots))
+	for _, snap := range snapshots {
+		view := portalPlayerView{
+			Name:     snap.Name,
+			Location: snap.RoomTitle,
+			RoomID:   string(snap.Room),
+			Roles:    playerRolesForSnapshot(snap),
+		}
+		if strings.TrimSpace(view.Location) == "" {
+			view.Location = view.RoomID
+		}
+		views = append(views, view)
+	}
+	data, _ := json.Marshal(views)
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	_, _ = w.Write(data)
+}
+
+func (p *PortalServer) consumeToken(token string) (portalToken, bool) {
+	now := time.Now()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.purgeExpiredLocked(now)
+	payload, ok := p.tokens[token]
+	if !ok {
+		return portalToken{}, false
+	}
+	delete(p.tokens, token)
+	if payload.Expires.Before(now) {
+		return portalToken{}, false
+	}
+	return payload, true
+}
+
+func (p *PortalServer) createSession(role PortalRole, player string) (string, portalSession, error) {
+	id, err := randomToken(portalSessionBytes)
+	if err != nil {
+		return "", portalSession{}, err
+	}
+	now := time.Now()
+	session := portalSession{
+		Role:    role,
+		Player:  player,
+		Expires: now.Add(p.sessionTTL),
+	}
+	p.mu.Lock()
+	p.purgeExpiredLocked(now)
+	p.sessions[id] = session
+	p.mu.Unlock()
+	return id, session, nil
+}
+
+func (p *PortalServer) sessionForRequest(r *http.Request) (portalSession, string, bool) {
+	cookie, err := r.Cookie(portalCookieName)
+	if err != nil {
+		return portalSession{}, "", false
+	}
+	id := strings.TrimSpace(cookie.Value)
+	if id == "" {
+		return portalSession{}, "", false
+	}
+	now := time.Now()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.purgeExpiredLocked(now)
+	session, ok := p.sessions[id]
+	if !ok {
+		return portalSession{}, "", false
+	}
+	session.Expires = now.Add(p.sessionTTL)
+	p.sessions[id] = session
+	return session, id, true
+}
+
+func (p *PortalServer) setSessionCookie(w http.ResponseWriter, id string, expires time.Time) {
+	ttl := time.Until(expires)
+	if ttl < 0 {
+		ttl = 0
+	}
+	cookie := &http.Cookie{
+		Name:     portalCookieName,
+		Value:    id,
+		Path:     "/",
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Expires:  expires,
+		MaxAge:   int(ttl.Seconds()),
+	}
+	http.SetCookie(w, cookie)
+}
+
+func (p *PortalServer) purgeExpiredLocked(now time.Time) {
+	for token, payload := range p.tokens {
+		if !payload.Expires.After(now) {
+			delete(p.tokens, token)
+		}
+	}
+	for id, session := range p.sessions {
+		if !session.Expires.After(now) {
+			delete(p.sessions, id)
+		}
+	}
+}
+
+func randomToken(length int) (string, error) {
+	buf := make([]byte, length)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+func isSupportedPortalRole(role PortalRole) bool {
+	switch role {
+	case PortalRoleBuilder, PortalRoleModerator, PortalRoleAdmin:
+		return true
+	default:
+		return false
+	}
+}
+
+type portalPlayerView struct {
+	Name     string   `json:"name"`
+	Location string   `json:"location"`
+	RoomID   string   `json:"room_id"`
+	Roles    []string `json:"roles"`
+}
+
+type portalPageData struct {
+	Player          string
+	Role            PortalRole
+	RoleTitle       string
+	RoleDescription string
+	Generated       string
+	SessionExpiry   string
+	Players         []portalPlayerView
+	PlayersJSON     template.JS
+}
+
+func playerRolesForSnapshot(s PlayerSnapshot) []string {
+	roles := []string{"Player"}
+	if s.IsBuilder {
+		roles = append(roles, "Builder")
+	}
+	if s.IsModerator {
+		roles = append(roles, "Moderator")
+	}
+	if s.IsAdmin {
+		roles = append(roles, "Admin")
+	}
+	return roles
+}
+
+func portalRoleTitle(role PortalRole) string {
+	switch role {
+	case PortalRoleAdmin:
+		return "LumenClay Administration"
+	case PortalRoleModerator:
+		return "LumenClay Moderation"
+	case PortalRoleBuilder:
+		fallthrough
+	default:
+		return "LumenClay Builder Tools"
+	}
+}
+
+func portalRoleDescription(role PortalRole) string {
+	switch role {
+	case PortalRoleAdmin:
+		return "Review online activity, manage resets, and coordinate large-scale changes."
+	case PortalRoleModerator:
+		return "Monitor player activity, coordinate community efforts, and respond to incidents."
+	case PortalRoleBuilder:
+		fallthrough
+	default:
+		return "Track the living world while sculpting new adventures."
+	}
+}
+
+var portalTemplate = template.Must(template.New("portal").Funcs(template.FuncMap{
+	"nowYear": func() int { return time.Now().Year() },
+}).Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>{{.RoleTitle}}</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<style>
+body { font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; background: #0f172a; color: #e2e8f0; }
+header { background: linear-gradient(120deg, #3b82f6, #06b6d4); padding: 2rem 3vw; }
+header h1 { margin: 0 0 0.25rem 0; font-size: 2rem; }
+header p { margin: 0.25rem 0; }
+main { padding: 2rem 3vw; }
+section { margin-bottom: 2rem; background: rgba(15, 23, 42, 0.65); border: 1px solid rgba(148, 163, 184, 0.2); border-radius: 1rem; padding: 1.5rem; box-shadow: 0 16px 32px rgba(15, 23, 42, 0.45); }
+section h2 { margin-top: 0; font-size: 1.4rem; color: #38bdf8; }
+.badge { display: inline-block; margin-right: 0.5rem; padding: 0.25rem 0.75rem; border-radius: 999px; background: rgba(56, 189, 248, 0.15); color: #bae6fd; font-size: 0.8rem; letter-spacing: 0.05em; text-transform: uppercase; }
+table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+th, td { padding: 0.75rem; text-align: left; border-bottom: 1px solid rgba(148, 163, 184, 0.25); }
+tr:last-child td { border-bottom: none; }
+.role-chip { display: inline-block; margin: 0 0.35rem 0.35rem 0; padding: 0.2rem 0.6rem; border-radius: 999px; background: rgba(148, 163, 184, 0.18); font-size: 0.75rem; }
+footer { text-align: center; font-size: 0.8rem; color: #94a3b8; padding: 2rem 0 3rem; }
+@media (max-width: 720px) {
+ header, main { padding-left: 6vw; padding-right: 6vw; }
+ table, thead, tbody, th, td, tr { display: block; }
+ thead { display: none; }
+ td { border: none; padding: 0.5rem 0; }
+ td::before { content: attr(data-label); font-weight: 600; display: block; color: #38bdf8; }
+}
+</style>
+</head>
+<body>
+<header>
+<div class="badge">{{.Role}}</div>
+<h1>{{.RoleTitle}}</h1>
+<p>Welcome, {{.Player}}. {{.RoleDescription}}</p>
+<p><small>Session active until {{.SessionExpiry}} · Refreshed {{.Generated}}</small></p>
+</header>
+<main>
+<section>
+<h2>World Activity</h2>
+<p>Review who is currently shaping the radiant clay.</p>
+<div id="players-container"></div>
+</section>
+<section>
+<h2>Quick Tips</h2>
+<ul>
+<li>Use <strong>history</strong>, <strong>where</strong>, and <strong>summon</strong> alongside this dashboard for rapid response.</li>
+<li>Keep links private — they expire after first use and refresh automatically while this page remains open.</li>
+<li>Need a new link? Run <code>portal</code> in-game again to refresh your secure access.</li>
+</ul>
+</section>
+</main>
+<footer>
+&copy; {{nowYear}} LumenClay. Crafted for collaborative storytelling.
+</footer>
+<script>
+const playersMount = document.getElementById('players-container');
+const renderPlayers = function(entries) {
+  if (!entries || !entries.length) {
+    playersMount.innerHTML = '<p>No adventurers are currently connected.</p>';
+    return;
+  }
+  var html = '<table><thead><tr><th>Name</th><th>Location</th><th>Roles</th></tr></thead><tbody>';
+  for (var i = 0; i < entries.length; i++) {
+    var entry = entries[i];
+    var roles = (entry.roles || []).map(function(role) { return '<span class="role-chip">' + role + '</span>'; }).join('');
+    html += '<tr><td data-label="Name">' + entry.name + '</td><td data-label="Location">' + entry.location + '</td><td data-label="Roles">' + roles + '</td></tr>';
+  }
+  html += '</tbody></table>';
+  playersMount.innerHTML = html;
+};
+const initialPlayers = {{.PlayersJSON}};
+renderPlayers(initialPlayers);
+const refresh = async () => {
+  try {
+    const response = await fetch('/api/players', { credentials: 'same-origin' });
+    if (!response.ok) {
+      return;
+    }
+    const next = await response.json();
+    renderPlayers(next);
+  } catch (err) {
+    console.warn('Portal refresh failed', err);
+  }
+};
+setInterval(refresh, 10000);
+</script>
+</body>
+</html>`))

--- a/internal/game/portal_test.go
+++ b/internal/game/portal_test.go
@@ -1,0 +1,114 @@
+package game
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPortalLinkSingleUse(t *testing.T) {
+	dir := t.TempDir()
+	cert := filepath.Join(dir, "portal-cert.pem")
+	key := filepath.Join(dir, "portal-key.pem")
+	world := NewWorldWithRooms(map[RoomID]*Room{
+		"start": {ID: "start", Title: "Atrium", Description: "", Exits: map[string]RoomID{}},
+	})
+	player := &Player{Name: "Builder", Room: "start", Alive: true, Output: make(chan string, 1)}
+	player.IsBuilder = true
+	world.AddPlayerForTest(player)
+
+	cfg := PortalConfig{Addr: "127.0.0.1:0", CertFile: cert, KeyFile: key}
+	provider, err := newPortalServer(world, cfg)
+	if err != nil {
+		t.Fatalf("newPortalServer error: %v", err)
+	}
+	portal := provider.(*PortalServer)
+	t.Cleanup(func() {
+		_ = portal.Close()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := portal.WaitReady(ctx); err != nil {
+		t.Fatalf("portal did not start: %v", err)
+	}
+
+	link, err := provider.GenerateLink(PortalRoleBuilder, "Builder")
+	if err != nil {
+		t.Fatalf("GenerateLink error: %v", err)
+	}
+	if !strings.Contains(link.URL, "https://") {
+		t.Fatalf("expected https link, got %q", link.URL)
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	resp, err := client.Get(link.URL)
+	if err != nil {
+		t.Fatalf("GET portal token failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("first response status = %d, want %d", resp.StatusCode, http.StatusSeeOther)
+	}
+	cookie := findPortalCookie(resp.Cookies())
+	if cookie == nil {
+		t.Fatalf("portal cookie not set on initial response")
+	}
+	resp.Body.Close()
+
+	interfaceURL, err := url.Parse(portal.BaseURL())
+	if err != nil {
+		t.Fatalf("parse base url: %v", err)
+	}
+	interfaceURL.Path = "/interface"
+	req, err := http.NewRequest(http.MethodGet, interfaceURL.String(), nil)
+	if err != nil {
+		t.Fatalf("create interface request: %v", err)
+	}
+	req.AddCookie(cookie)
+	resp2, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("GET interface failed: %v", err)
+	}
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("interface status = %d, want %d", resp2.StatusCode, http.StatusOK)
+	}
+	bodyBytes, err := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+	if err != nil {
+		t.Fatalf("read interface body: %v", err)
+	}
+	body := string(bodyBytes)
+	if !strings.Contains(body, "LumenClay") {
+		t.Fatalf("interface response missing branding: %q", body)
+	}
+
+	resp3, err := client.Get(link.URL)
+	if err != nil {
+		t.Fatalf("reusing token failed: %v", err)
+	}
+	if resp3.StatusCode != http.StatusNotFound {
+		t.Fatalf("token reuse status = %d, want %d", resp3.StatusCode, http.StatusNotFound)
+	}
+	resp3.Body.Close()
+}
+
+func findPortalCookie(cookies []*http.Cookie) *http.Cookie {
+	for _, c := range cookies {
+		if c.Name == portalCookieName {
+			return c
+		}
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -20,6 +20,10 @@ func main() {
 	areasPath := flag.String("areas", game.DefaultAreasPath, "Directory containing world area definitions")
 	mailPath := flag.String("mail", "", "Optional path to persistent mail storage (defaults beside the accounts file)")
 	tellsPath := flag.String("tells", "", "Optional path to offline tells storage (defaults beside the accounts file)")
+	webAddr := flag.String("web-addr", ":4443", "HTTPS address for the staff web portal (empty disables)")
+	webCert := flag.String("web-cert", "data/tls/web_cert.pem", "Path to the web portal TLS certificate file")
+	webKey := flag.String("web-key", "data/tls/web_key.pem", "Path to the web portal TLS private key file")
+	webBase := flag.String("web-base-url", "", "Optional external base URL for portal links")
 	flag.Parse()
 
 	var options []game.ServerOption
@@ -28,6 +32,15 @@ func main() {
 	}
 	if trimmed := strings.TrimSpace(*tellsPath); trimmed != "" {
 		options = append(options, game.WithTellPath(trimmed))
+	}
+	if trimmed := strings.TrimSpace(*webAddr); trimmed != "" {
+		portalCfg := game.PortalConfig{
+			Addr:     trimmed,
+			BaseURL:  strings.TrimSpace(*webBase),
+			CertFile: *webCert,
+			KeyFile:  *webKey,
+		}
+		options = append(options, game.WithPortalConfig(portalCfg))
 	}
 
 	var err error


### PR DESCRIPTION
## Summary
- introduce an HTTPS staff portal backed by one-use tokens and session cookies, including JSON API and live player snapshot data
- add portal command plus moderator role support to generate builder/moderator/admin links, with tests covering new behaviors
- wire portal configuration through CLI flags, update documentation, and ensure new moderator command toggles privileges

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d84c980a60832abdcab330eae57377