### PR TITLE
Simplify TLS flags to shared cert path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Agent Guidelines
+
+- Keep the README and any in-game help text (command descriptions, help listings, etc.) synchronized whenever you change server configuration, flags, or gameplay instructions.
+- Update this file if the documentation workflow changes so future updates keep docs current.

--- a/README.md
+++ b/README.md
@@ -51,12 +51,31 @@ When overriding the accounts file, persistent mail and offline tells automatical
 go run . -accounts /var/lumen/accounts.json -mail /srv/mailbox.json -tells /srv/tells.json
 ```
 
-Enable TLS by passing `-tls`. By default the server stores its certificate at `data/tls/cert.pem` and private key at `data/tls/key.pem`,
-and you can override these paths with the `-cert` and `-key` flags:
+Enable TLS by passing `-tls`. By default the server looks for certificate files that follow the
+[Certbot](https://certbot.eff.org/) naming convention: `data/tls/fullchain.pem` and `data/tls/privkey.pem`.
+The MUD listener and the staff web portal share these files so a single certificate
+covers both telnet and HTTPS. Point `-cert` at another directory or bundle if your
+files live elsewhere. When you supply a directory, the server reads `fullchain.pem`
+and `privkey.pem` from within it. When you supply an explicit certificate file,
+`privkey.pem` in the same directory (or a `.key` that shares the certificate's base
+name) is used for the private key:
 
 ```bash
-go run . -tls -cert /path/to/cert.pem -key /path/to/key.pem
+go run . -tls -cert /etc/letsencrypt/live/example.com
 ```
+
+When HTTPS is enabled, the staff web portal automatically binds to the same host as the MUD listener on port `443` and reuses the
+TLS certificate and key. Override the default host, port, or certificate bundle if you need
+to split the services:
+
+- `-web-addr auto` (default) &mdash; use the host from `-addr` on port `443`.
+- `-web-addr off` &mdash; disable the portal entirely.
+- `-web-addr host:port` &mdash; listen on a custom HTTPS address.
+- `-web-cert auto` &mdash; reuse the `-cert` path (default).
+- `-web-cert PATH` &mdash; point the portal to a different certificate directory or bundle.
+
+The server generates a self-signed certificate the first time it starts if the specified
+files do not exist and reuses that certificate afterwards.
 
 Choose which account should receive administrator privileges by using the `-admin` flag (case-insensitive). For example, to grant the
 `Wizard` account admin rights:
@@ -64,9 +83,6 @@ Choose which account should receive administrator privileges by using the `-admi
 ```bash
 go run . -admin Wizard
 ```
-
-When the specified certificate or key files do not exist, `ListenAndServeTLS` automatically generates a self-signed certificate the
-first time the server starts and reuses it on subsequent runs.
 
 To stop the server, press `Ctrl+C` in the terminal running `go run .` or terminate the compiled binary if you used `go build`.
 
@@ -104,7 +120,7 @@ After logging in, type `help` (or `?`) to see the in-game reference. Common comm
 - `quit` &mdash; Disconnect from the server.
 - `reboot` (admin only) &mdash; Reload the world data and return everyone to the starting room.
 - `buildhelp` (builders/admins) &mdash; List the online creation commands available to builders.
-- `portal [builder|moderator|admin]` (builders/moderators/admins) &mdash; Generate a one-use HTTPS link to the staff web portal.
+- `portal [builder|moderator|admin]` (builders/moderators/admins) &mdash; Generate a one-use HTTPS link to the staff web portal when it is configured.
 - `wizhelp` (admin only) &mdash; List administrative commands such as `reboot` and `summon`.
 
 Climb to the Glazemaker's Overlook from the starting atrium and head north to reach the new Celestial Observatory. There you'll find the Horizon Plaza, Zephyr Rampart, Astral Scriptorium, and the Lenswright Workshop, now joined by the Arcade of Shifting Sundials, a noctilucent reflecting pool, and an expanded vertical circuit that threads through the Aurora Spire, its heliograph gallery, a chart vault walkway, and the tea-scented loft of Professor Orrin before cresting at the beaconry. The subterranean Starwell, Resonance Vault, and Gravity Underchamber remain below, rounding out a sky-struck ascent packed with NPCs and artifacts.

--- a/commands/portal.go
+++ b/commands/portal.go
@@ -11,12 +11,12 @@ import (
 var Portal = Define(Definition{
 	Name:        "portal",
 	Usage:       "portal [builder|moderator|admin]",
-	Description: "generate a secure one-use web portal link",
+	Description: "generate a secure one-use staff portal link",
 	Group:       GroupBuilder,
 }, func(ctx *Context) bool {
 	provider := ctx.World.Portal()
 	if provider == nil {
-		ctx.Player.Output <- game.Ansi(game.Style("\r\nThe web portal is not configured.", game.AnsiYellow))
+		ctx.Player.Output <- game.Ansi(game.Style("\r\nThe web portal is not configured. Ask an admin to enable TLS (default Certbot fullchain.pem/privkey.pem) or supply --web-addr.", game.AnsiYellow))
 		return false
 	}
 

--- a/main.go
+++ b/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"flag"
 	"log"
+	"net"
+	"path/filepath"
 	"strings"
 
 	"LumenClay/commands"
@@ -12,19 +14,21 @@ import (
 func main() {
 	addr := flag.String("addr", ":4000", "TCP address to listen on")
 	useTLS := flag.Bool("tls", false, "Enable TLS using the provided certificate and key files")
-	certFile := flag.String("cert", "data/tls/cert.pem", "Path to the TLS certificate file")
-	keyFile := flag.String("key", "data/tls/key.pem", "Path to the TLS private key file")
+	certPath := flag.String("cert", "data/tls", "Path to the TLS certificate directory or bundle (Certbot fullchain.pem/privkey.pem)")
 	adminAccount := flag.String("admin", "admin", "Account granted administrator privileges")
 	everyoneAdmin := flag.Bool("everyone-admin", false, "Grant administrator privileges to all players while disabling reboot and shutdown commands")
 	accountsPath := flag.String("accounts", "data/accounts.json", "Path to the player accounts database")
 	areasPath := flag.String("areas", game.DefaultAreasPath, "Directory containing world area definitions")
 	mailPath := flag.String("mail", "", "Optional path to persistent mail storage (defaults beside the accounts file)")
 	tellsPath := flag.String("tells", "", "Optional path to offline tells storage (defaults beside the accounts file)")
-	webAddr := flag.String("web-addr", ":4443", "HTTPS address for the staff web portal (empty disables)")
-	webCert := flag.String("web-cert", "data/tls/web_cert.pem", "Path to the web portal TLS certificate file")
-	webKey := flag.String("web-key", "data/tls/web_key.pem", "Path to the web portal TLS private key file")
+	webAddr := flag.String("web-addr", "auto", "HTTPS address for the staff web portal (auto matches --addr on port 443; empty disables)")
+	webCert := flag.String("web-cert", "auto", "Path to the web portal TLS certificate directory or bundle (auto uses --cert)")
 	webBase := flag.String("web-base-url", "", "Optional external base URL for portal links")
 	flag.Parse()
+
+	mudCertFile, mudKeyFile := expandCertPaths(*certPath)
+	portalCertBase := resolveCertBase(*webCert, *certPath)
+	portalCertFile, portalKeyFile := expandCertPaths(portalCertBase)
 
 	var options []game.ServerOption
 	if trimmed := strings.TrimSpace(*mailPath); trimmed != "" {
@@ -33,19 +37,19 @@ func main() {
 	if trimmed := strings.TrimSpace(*tellsPath); trimmed != "" {
 		options = append(options, game.WithTellPath(trimmed))
 	}
-	if trimmed := strings.TrimSpace(*webAddr); trimmed != "" {
+	if resolved := resolveWebAddr(*webAddr, *addr); resolved != "" {
 		portalCfg := game.PortalConfig{
-			Addr:     trimmed,
+			Addr:     resolved,
 			BaseURL:  strings.TrimSpace(*webBase),
-			CertFile: *webCert,
-			KeyFile:  *webKey,
+			CertFile: portalCertFile,
+			KeyFile:  portalKeyFile,
 		}
 		options = append(options, game.WithPortalConfig(portalCfg))
 	}
 
 	var err error
 	if *useTLS {
-		err = game.ListenAndServeTLS(*addr, *accountsPath, *areasPath, *certFile, *keyFile, *adminAccount, commands.Dispatch, *everyoneAdmin, options...)
+		err = game.ListenAndServeTLS(*addr, *accountsPath, *areasPath, mudCertFile, mudKeyFile, *adminAccount, commands.Dispatch, *everyoneAdmin, options...)
 	} else {
 		err = game.ListenAndServe(*addr, *accountsPath, *areasPath, *adminAccount, commands.Dispatch, *everyoneAdmin, options...)
 	}
@@ -53,4 +57,56 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+}
+
+func resolveWebAddr(flagValue, mudAddr string) string {
+	trimmed := strings.TrimSpace(flagValue)
+	switch strings.ToLower(trimmed) {
+	case "", "disable", "disabled", "off":
+		return ""
+	case "auto":
+		host, _, err := net.SplitHostPort(mudAddr)
+		if err != nil {
+			host = strings.TrimSpace(mudAddr)
+		}
+		if host == "" {
+			return ":443"
+		}
+		return net.JoinHostPort(host, "443")
+	default:
+		return trimmed
+	}
+}
+
+func resolveCertBase(flagValue, defaultValue string) string {
+	trimmed := strings.TrimSpace(flagValue)
+	if trimmed == "" || strings.EqualFold(trimmed, "auto") {
+		return strings.TrimSpace(defaultValue)
+	}
+	return trimmed
+}
+
+func expandCertPaths(base string) (string, string) {
+	trimmed := strings.TrimSpace(base)
+	if trimmed == "" {
+		trimmed = "data/tls"
+	}
+	if ext := strings.ToLower(filepath.Ext(trimmed)); ext == ".pem" || ext == ".crt" || ext == ".cer" {
+		dir := filepath.Dir(trimmed)
+		file := strings.ToLower(filepath.Base(trimmed))
+		switch file {
+		case "privkey.pem":
+			return filepath.Join(dir, "fullchain.pem"), trimmed
+		case "fullchain.pem", "cert.pem", "certificate.pem":
+			return trimmed, filepath.Join(dir, "privkey.pem")
+		default:
+			name := strings.TrimSuffix(filepath.Base(trimmed), filepath.Ext(trimmed))
+			return trimmed, filepath.Join(dir, name+".key")
+		}
+	}
+	trimmed = strings.TrimSuffix(trimmed, string(filepath.Separator))
+	if trimmed == "" {
+		trimmed = "data/tls"
+	}
+	return filepath.Join(trimmed, "fullchain.pem"), filepath.Join(trimmed, "privkey.pem")
 }


### PR DESCRIPTION
## Summary
- derive the MUD and portal TLS files from a shared certificate path while keeping auto portal configuration
- document the new `-cert` and `-web-cert` semantics so operators know how to point at Certbot directories

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d867890ba8832aa7bde3f092fcd413