### PR TITLE
Default TLS certs to project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ When overriding the accounts file, persistent mail and offline tells automatical
 go run . -accounts /var/lumen/accounts.json -mail /srv/mailbox.json -tells /srv/tells.json
 ```
 
-Enable TLS by passing `-tls`. By default the server looks for certificate files that follow the
-[Certbot](https://certbot.eff.org/) naming convention: `data/tls/fullchain.pem` and `data/tls/privkey.pem`.
+Enable TLS by passing `-tls`. By default the server looks for certificate files in the project root that follow the
+[Certbot](https://certbot.eff.org/) naming convention: `fullchain.pem` and `privkey.pem`.
 The MUD listener and the staff web portal share these files so a single certificate
 covers both telnet and HTTPS. Point `-cert` at another directory or bundle if your
 files live elsewhere. When you supply a directory, the server reads `fullchain.pem`

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	addr := flag.String("addr", ":4000", "TCP address to listen on")
 	useTLS := flag.Bool("tls", false, "Enable TLS using the provided certificate and key files")
-	certPath := flag.String("cert", "data/tls", "Path to the TLS certificate directory or bundle (Certbot fullchain.pem/privkey.pem)")
+	certPath := flag.String("cert", ".", "Path to the TLS certificate directory or bundle (Certbot fullchain.pem/privkey.pem; defaults to project root)")
 	adminAccount := flag.String("admin", "admin", "Account granted administrator privileges")
 	everyoneAdmin := flag.Bool("everyone-admin", false, "Grant administrator privileges to all players while disabling reboot and shutdown commands")
 	accountsPath := flag.String("accounts", "data/accounts.json", "Path to the player accounts database")
@@ -89,7 +89,7 @@ func resolveCertBase(flagValue, defaultValue string) string {
 func expandCertPaths(base string) (string, string) {
 	trimmed := strings.TrimSpace(base)
 	if trimmed == "" {
-		trimmed = "data/tls"
+		trimmed = "."
 	}
 	if ext := strings.ToLower(filepath.Ext(trimmed)); ext == ".pem" || ext == ".crt" || ext == ".cer" {
 		dir := filepath.Dir(trimmed)
@@ -106,7 +106,7 @@ func expandCertPaths(base string) (string, string) {
 	}
 	trimmed = strings.TrimSuffix(trimmed, string(filepath.Separator))
 	if trimmed == "" {
-		trimmed = "data/tls"
+		trimmed = "."
 	}
 	return filepath.Join(trimmed, "fullchain.pem"), filepath.Join(trimmed, "privkey.pem")
 }


### PR DESCRIPTION
## Summary
- default the TLS certificate flag to the project root so fullchain/privkey are expected there
- update the README to document the new default certificate location

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d86f11f290832ab5b8f73925408a3e