### PR TITLE
Add moderator portal guidance to help command

### DIFF
--- a/commands/help.go
+++ b/commands/help.go
@@ -21,6 +21,9 @@ var Help = Define(Definition{
 	if ctx.Player.IsAdmin {
 		message += "\r\nType 'wizhelp' for admin commands."
 	}
+	if ctx.Player.IsModerator {
+		message += "\r\nModerators may type 'portal' to request a moderation portal link."
+	}
 	ctx.Player.Output <- game.Ansi(message)
 	return false
 })

--- a/commands/help_test.go
+++ b/commands/help_test.go
@@ -1,0 +1,55 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"LumenClay/internal/game"
+)
+
+func TestHelpMentionsPortalForModerators(t *testing.T) {
+	world := game.NewWorldWithRooms(map[game.RoomID]*game.Room{
+		"start": {
+			ID:          "start",
+			Title:       "Start",
+			Description: "Start room.",
+			Exits:       map[string]game.RoomID{},
+		},
+	})
+	moderator := newTestPlayer("Moderator", "start")
+	moderator.IsModerator = true
+	world.AddPlayerForTest(moderator)
+
+	if quit := Dispatch(world, moderator, "help"); quit {
+		t.Fatalf("dispatch returned true, want false")
+	}
+
+	msgs := drainOutput(moderator.Output)
+	text := strings.Join(msgs, "\n")
+	if !strings.Contains(text, "Moderators may type 'portal' to request a moderation portal link.") {
+		t.Fatalf("help output missing moderator portal note: %v", msgs)
+	}
+}
+
+func TestHelpOmitsPortalNoteForAdventurers(t *testing.T) {
+	world := game.NewWorldWithRooms(map[game.RoomID]*game.Room{
+		"start": {
+			ID:          "start",
+			Title:       "Start",
+			Description: "Start room.",
+			Exits:       map[string]game.RoomID{},
+		},
+	})
+	player := newTestPlayer("Traveler", "start")
+	world.AddPlayerForTest(player)
+
+	if quit := Dispatch(world, player, "help"); quit {
+		t.Fatalf("dispatch returned true, want false")
+	}
+
+	msgs := drainOutput(player.Output)
+	text := strings.Join(msgs, "\n")
+	if strings.Contains(text, "Moderators may type 'portal' to request a moderation portal link.") {
+		t.Fatalf("unexpected moderator portal note for regular player: %v", msgs)
+	}
+}


### PR DESCRIPTION
## Summary
- mention the portal command in help output for moderators
- add unit tests covering the moderator portal help text

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d9dbe71658832aaf96f80aaccc9043