### PR TITLE
Allow players to access portal notes with script formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,14 @@ files do not exist and reuses that certificate afterwards.
 
 ### Staff web portal
 
-When HTTPS is enabled (see `-tls` above) staff can request a one-use link with the
-`portal` command to reach a browser dashboard. The portal now includes:
+When HTTPS is enabled (see `-tls` above) any player can request a one-use link with the
+`portal` command to open the shared notes workspace, while staff can access the full dashboard. The portal now includes:
 
 - Real-time "At a Glance" cards that summarize total online players, staff coverage, and average session length.
 - A detailed player table with level, health, mana, connected-room information, and live session timers.
 - JSON APIs at `/api/players` (player list + stats) and `/api/overview` (aggregated staff metrics) for custom tooling.
+- A collaborative notes workspace at `/api/documents` that lets everyone capture descriptions and planning notes directly from the browser (up to 24 documents, 16 KB each).
+- Builders, moderators, and admins can mark a document as a Go script to receive in-browser highlighting along with gofmt formatting and validation before the draft is saved.
 
 Choose which account should receive administrator privileges by using the `-admin` flag (case-insensitive). For example, to grant the
 `Wizard` account admin rights:
@@ -130,7 +132,7 @@ After logging in, type `help` (or `?`) to see the in-game reference. Common comm
 - `quit` &mdash; Disconnect from the server.
 - `reboot` (admin only) &mdash; Reload the world data and return everyone to the starting room.
 - `buildhelp` (builders/admins) &mdash; List the online creation commands available to builders.
-- `portal [builder|moderator|admin]` (builders/moderators/admins) &mdash; Generate a one-use HTTPS link to the staff web portal when it is configured.
+- `portal [notes|builder|moderator|admin]` (all players for `notes`; builder/moderator/admin require the matching role) &mdash; Generate a one-use HTTPS link to the collaborative notes space or the staff dashboards when configured.
 - `wizhelp` (admin only) &mdash; List administrative commands such as `reboot` and `summon`.
 
 Climb to the Glazemaker's Overlook from the starting atrium and head north to reach the new Celestial Observatory. There you'll find the Horizon Plaza, Zephyr Rampart, Astral Scriptorium, and the Lenswright Workshop, now joined by the Arcade of Shifting Sundials, a noctilucent reflecting pool, and an expanded vertical circuit that threads through the Aurora Spire, its heliograph gallery, a chart vault walkway, and the tea-scented loft of Professor Orrin before cresting at the beaconry. The subterranean Starwell, Resonance Vault, and Gravity Underchamber remain below, rounding out a sky-struck ascent packed with NPCs and artifacts.

--- a/commands/portal.go
+++ b/commands/portal.go
@@ -10,9 +10,9 @@ import (
 
 var Portal = Define(Definition{
 	Name:        "portal",
-	Usage:       "portal [builder|moderator|admin]",
-	Description: "generate a secure one-use staff portal link",
-	Group:       GroupBuilder,
+	Usage:       "portal [notes|builder|moderator|admin]",
+	Description: "generate a secure one-use web portal link",
+	Group:       GroupGeneral,
 }, func(ctx *Context) bool {
 	provider := ctx.World.Portal()
 	if provider == nil {
@@ -26,7 +26,7 @@ var Portal = Define(Definition{
 		if requested != "" {
 			ctx.Player.Output <- game.Ansi(game.Style("\r\nYou are not permitted to request that portal.", game.AnsiYellow))
 		} else {
-			ctx.Player.Output <- game.Ansi(game.Style("\r\nOnly builders, moderators, or admins may request portal links.", game.AnsiYellow))
+			ctx.Player.Output <- game.Ansi(game.Style("\r\nRequest a specific portal with notes, builder, moderator, or admin.", game.AnsiYellow))
 		}
 		return false
 	}
@@ -52,6 +52,8 @@ var Portal = Define(Definition{
 
 func selectPortalRole(player *game.Player, requested string) (game.PortalRole, bool) {
 	switch requested {
+	case "notes", "player", "note":
+		return game.PortalRolePlayer, true
 	case "builder":
 		if player.IsBuilder || player.IsAdmin || player.IsModerator {
 			return game.PortalRoleBuilder, true
@@ -76,7 +78,7 @@ func selectPortalRole(player *game.Player, requested string) (game.PortalRole, b
 		case player.IsBuilder:
 			return game.PortalRoleBuilder, true
 		default:
-			return "", false
+			return game.PortalRolePlayer, true
 		}
 	default:
 		return "", false
@@ -89,6 +91,8 @@ func portalRoleLabel(role game.PortalRole) string {
 		return "Administration"
 	case game.PortalRoleModerator:
 		return "Moderation"
+	case game.PortalRolePlayer:
+		return "Notes"
 	default:
 		return "Builder"
 	}

--- a/commands/portal_test.go
+++ b/commands/portal_test.go
@@ -62,3 +62,18 @@ func TestPortalCommandGeneratesLink(t *testing.T) {
 		t.Fatalf("portal requested role %q, want %q", fake.lastRole, game.PortalRoleModerator)
 	}
 }
+
+func TestSelectPortalRoleForPlayers(t *testing.T) {
+	traveler := newTestPlayer("Traveler", "start")
+	role, ok := selectPortalRole(traveler, "")
+	if !ok || role != game.PortalRolePlayer {
+		t.Fatalf("default role = %q ok=%v, want %q true", role, ok, game.PortalRolePlayer)
+	}
+	role, ok = selectPortalRole(traveler, "notes")
+	if !ok || role != game.PortalRolePlayer {
+		t.Fatalf("notes role = %q ok=%v, want %q true", role, ok, game.PortalRolePlayer)
+	}
+	if role, ok = selectPortalRole(traveler, "builder"); ok || role != "" {
+		t.Fatalf("unauthorized builder request returned role %q ok=%v", role, ok)
+	}
+}

--- a/internal/game/portal.go
+++ b/internal/game/portal.go
@@ -8,12 +8,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"go/format"
 	"html/template"
 	"net"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 )
 
 // PortalRole identifies the interface exposed by the web portal.
@@ -30,6 +32,8 @@ const (
 	PortalRoleModerator PortalRole = "moderator"
 	// PortalRoleAdmin grants access to privileged administration views.
 	PortalRoleAdmin PortalRole = "admin"
+	// PortalRolePlayer grants access to collaborative notes only.
+	PortalRolePlayer PortalRole = "player"
 )
 
 // PortalLink bundles the generated URL with its expiry.
@@ -64,6 +68,31 @@ const (
 	portalCookieName     = "lc_portal"
 )
 
+const (
+	portalDocumentLimit    = 24
+	portalDocumentMaxBytes = 16 * 1024
+	portalDocumentMaxTitle = 120
+)
+
+type portalDocumentType string
+
+const (
+	portalDocumentTypeNote   portalDocumentType = "note"
+	portalDocumentTypeScript portalDocumentType = "script"
+)
+
+type portalDocumentError struct {
+	status  int
+	message string
+}
+
+func (e portalDocumentError) Error() string {
+	if strings.TrimSpace(e.message) == "" {
+		return "document error"
+	}
+	return e.message
+}
+
 type portalToken struct {
 	Role    PortalRole
 	Player  string
@@ -83,9 +112,11 @@ type PortalServer struct {
 	tokenTTL   time.Duration
 	sessionTTL time.Duration
 
-	mu       sync.Mutex
-	tokens   map[string]portalToken
-	sessions map[string]portalSession
+	mu        sync.Mutex
+	tokens    map[string]portalToken
+	sessions  map[string]portalSession
+	documents map[string]portalDocument
+	docOrder  []string
 
 	server   *http.Server
 	listener net.Listener
@@ -145,6 +176,7 @@ func newPortalServer(world *World, cfg PortalConfig) (PortalProvider, error) {
 		sessionTTL: sessionTTL,
 		tokens:     make(map[string]portalToken),
 		sessions:   make(map[string]portalSession),
+		documents:  make(map[string]portalDocument),
 		server:     server,
 		listener:   listener,
 		ready:      make(chan struct{}),
@@ -156,6 +188,7 @@ func newPortalServer(world *World, cfg PortalConfig) (PortalProvider, error) {
 	mux.HandleFunc("/interface", portal.handleInterface)
 	mux.HandleFunc("/api/players", portal.handlePlayersAPI)
 	mux.HandleFunc("/api/overview", portal.handleOverviewAPI)
+	mux.HandleFunc("/api/documents", portal.handleDocumentsAPI)
 	server.Handler = portal.addSecurityHeaders(mux)
 
 	go func() {
@@ -300,20 +333,40 @@ func (p *PortalServer) handleInterface(w http.ResponseWriter, r *http.Request) {
 	}
 	p.setSessionCookie(w, id, session.Expires)
 	now := time.Now()
-	views, overview := p.collectPortalData(now)
+	var (
+		views    []portalPlayerView
+		overview portalOverview
+	)
+	if isStaffPortalRole(session.Role) {
+		views, overview = p.collectPortalData(now)
+	} else {
+		views = []portalPlayerView{}
+	}
+	documents := p.documentSnapshotsForRole(session.Role)
+	if documents == nil {
+		documents = []portalDocumentView{}
+	}
 	dataBytes, _ := json.Marshal(views)
 	overviewBytes, _ := json.Marshal(overview)
+	documentsBytes, _ := json.Marshal(documents)
 	tplData := portalPageData{
-		Player:          session.Player,
-		Role:            session.Role,
-		RoleTitle:       portalRoleTitle(session.Role),
-		RoleDescription: portalRoleDescription(session.Role),
-		Generated:       now.Format(time.RFC1123),
-		SessionExpiry:   session.Expires.Format(time.RFC1123),
-		Players:         views,
-		PlayersJSON:     template.JS(dataBytes),
-		OverviewCounts:  overview,
-		OverviewJSON:    template.JS(overviewBytes),
+		Player:           session.Player,
+		Role:             session.Role,
+		RoleTitle:        portalRoleTitle(session.Role),
+		RoleDescription:  portalRoleDescription(session.Role),
+		Generated:        now.Format(time.RFC1123),
+		SessionExpiry:    session.Expires.Format(time.RFC1123),
+		Players:          views,
+		PlayersJSON:      template.JS(dataBytes),
+		OverviewCounts:   overview,
+		OverviewJSON:     template.JS(overviewBytes),
+		Documents:        documents,
+		DocumentsJSON:    template.JS(documentsBytes),
+		ShowStaffPanels:  isStaffPortalRole(session.Role),
+		AllowScripts:     roleAllowsScripts(session.Role),
+		DocumentLimit:    portalDocumentLimit,
+		DocumentMaxSize:  portalDocumentMaxBytes,
+		DocumentMaxLabel: formatDocumentSize(portalDocumentMaxBytes),
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := portalTemplate.Execute(w, tplData); err != nil {
@@ -416,6 +469,74 @@ func (p *PortalServer) handleOverviewAPI(w http.ResponseWriter, r *http.Request)
 	_, _ = w.Write(data)
 }
 
+func (p *PortalServer) handleDocumentsAPI(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet, http.MethodPost:
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	session, id, ok := p.sessionForRequest(r)
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	p.setSessionCookie(w, id, session.Expires)
+
+	switch r.Method {
+	case http.MethodGet:
+		docID := strings.TrimSpace(r.URL.Query().Get("id"))
+		if docID == "" {
+			docs := p.documentSnapshotsForRole(session.Role)
+			if docs == nil {
+				docs = []portalDocumentView{}
+			}
+			data, _ := json.Marshal(docs)
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Cache-Control", "no-store")
+			_, _ = w.Write(data)
+			return
+		}
+		doc, found := p.documentByIDForRole(session.Role, docID)
+		if !found {
+			http.NotFound(w, r)
+			return
+		}
+		data, _ := json.Marshal(doc)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
+		_, _ = w.Write(data)
+	case http.MethodPost:
+		defer r.Body.Close()
+		var payload struct {
+			ID      string `json:"id"`
+			Title   string `json:"title"`
+			Content string `json:"content"`
+			Type    string `json:"type"`
+		}
+		decoder := json.NewDecoder(r.Body)
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&payload); err != nil {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		doc, err := p.saveDocument(session, payload.ID, payload.Title, payload.Content, payload.Type)
+		if err != nil {
+			var docErr portalDocumentError
+			if errors.As(err, &docErr) {
+				http.Error(w, docErr.Error(), docErr.status)
+				return
+			}
+			http.Error(w, "unable to save", http.StatusInternalServerError)
+			return
+		}
+		data, _ := json.Marshal(doc)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
+		_, _ = w.Write(data)
+	}
+}
+
 func (p *PortalServer) consumeToken(token string) (portalToken, bool) {
 	now := time.Now()
 	p.mu.Lock()
@@ -503,6 +624,199 @@ func (p *PortalServer) purgeExpiredLocked(now time.Time) {
 	}
 }
 
+func (p *PortalServer) documentSnapshotsForRole(role PortalRole) []portalDocumentView {
+	allowed := allowedDocumentTypes(role)
+	if len(allowed) == 0 {
+		return nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.documents) == 0 {
+		return nil
+	}
+	views := make([]portalDocumentView, 0, len(p.docOrder))
+	for _, id := range p.docOrder {
+		doc, ok := p.documents[id]
+		if !ok {
+			continue
+		}
+		if !allowed[doc.Type] {
+			continue
+		}
+		views = append(views, doc.view())
+	}
+	return views
+}
+
+func (p *PortalServer) documentByIDForRole(role PortalRole, id string) (portalDocumentView, bool) {
+	allowed := allowedDocumentTypes(role)
+	if len(allowed) == 0 {
+		return portalDocumentView{}, false
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	doc, ok := p.documents[id]
+	if !ok {
+		return portalDocumentView{}, false
+	}
+	if !allowed[doc.Type] {
+		return portalDocumentView{}, false
+	}
+	return doc.view(), true
+}
+
+func (p *PortalServer) saveDocument(session portalSession, id, title, content, requestedType string) (portalDocumentView, error) {
+	editor := strings.TrimSpace(session.Player)
+	title = clampDocumentTitle(title)
+	docType := normalizeDocumentType(session.Role, requestedType)
+
+	if len(content) > portalDocumentMaxBytes {
+		return portalDocumentView{}, portalDocumentError{status: http.StatusRequestEntityTooLarge, message: fmt.Sprintf("document content exceeds %d bytes", portalDocumentMaxBytes)}
+	}
+	if docType == portalDocumentTypeScript {
+		formatted, err := format.Source([]byte(content))
+		if err != nil {
+			return portalDocumentView{}, portalDocumentError{status: http.StatusBadRequest, message: fmt.Sprintf("script validation failed: %v", err)}
+		}
+		content = string(formatted)
+		if len(content) > portalDocumentMaxBytes {
+			return portalDocumentView{}, portalDocumentError{status: http.StatusRequestEntityTooLarge, message: fmt.Sprintf("formatted script exceeds %d bytes", portalDocumentMaxBytes)}
+		}
+	} else if strings.TrimSpace(content) == "" {
+		return portalDocumentView{}, portalDocumentError{status: http.StatusBadRequest, message: "document must include some content"}
+	}
+
+	now := time.Now().UTC()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if id != "" {
+		if doc, ok := p.documents[id]; ok {
+			if !allowedDocumentTypes(session.Role)[doc.Type] {
+				return portalDocumentView{}, portalDocumentError{status: http.StatusForbidden, message: "you cannot modify this document"}
+			}
+			doc.Title = title
+			doc.Content = content
+			doc.Type = docType
+			doc.UpdatedAt = now
+			doc.UpdatedBy = editor
+			p.documents[id] = doc
+			p.promoteDocumentLocked(id)
+			return doc.view(), nil
+		}
+	}
+
+	if len(p.documents) >= portalDocumentLimit {
+		p.trimDocumentLimitLocked()
+	}
+
+	newID, err := randomToken(12)
+	if err != nil {
+		return portalDocumentView{}, err
+	}
+	doc := portalDocument{
+		ID:        newID,
+		Title:     title,
+		Content:   content,
+		Type:      docType,
+		UpdatedAt: now,
+		UpdatedBy: editor,
+	}
+	p.documents[newID] = doc
+	p.promoteDocumentLocked(newID)
+	return doc.view(), nil
+}
+
+func (p *PortalServer) promoteDocumentLocked(id string) {
+	order := make([]string, 0, len(p.docOrder)+1)
+	order = append(order, id)
+	for _, existing := range p.docOrder {
+		if existing == id {
+			continue
+		}
+		order = append(order, existing)
+	}
+	p.docOrder = order
+}
+
+func (p *PortalServer) trimDocumentLimitLocked() {
+	if len(p.documents) < portalDocumentLimit {
+		return
+	}
+	if len(p.docOrder) == 0 {
+		return
+	}
+	keep := make([]string, 0, len(p.docOrder))
+	for _, id := range p.docOrder {
+		if _, ok := p.documents[id]; ok {
+			keep = append(keep, id)
+		}
+	}
+	p.docOrder = keep
+	for len(p.documents) >= portalDocumentLimit && len(p.docOrder) > 0 {
+		tailIdx := len(p.docOrder) - 1
+		purgeID := p.docOrder[tailIdx]
+		p.docOrder = p.docOrder[:tailIdx]
+		delete(p.documents, purgeID)
+	}
+}
+
+func (d portalDocument) view() portalDocumentView {
+	docType := d.Type
+	if docType == "" {
+		docType = portalDocumentTypeNote
+	}
+	view := portalDocumentView{
+		ID:      d.ID,
+		Title:   d.Title,
+		Content: d.Content,
+		Type:    string(docType),
+	}
+	if !d.UpdatedAt.IsZero() {
+		view.UpdatedAt = d.UpdatedAt.UTC().Format(time.RFC3339)
+	}
+	if strings.TrimSpace(d.UpdatedBy) != "" {
+		view.UpdatedBy = d.UpdatedBy
+	}
+	return view
+}
+
+func allowedDocumentTypes(role PortalRole) map[portalDocumentType]bool {
+	allowed := map[portalDocumentType]bool{portalDocumentTypeNote: true}
+	if roleAllowsScripts(role) {
+		allowed[portalDocumentTypeScript] = true
+	}
+	return allowed
+}
+
+func normalizeDocumentType(role PortalRole, requested string) portalDocumentType {
+	normalized := portalDocumentType(strings.ToLower(strings.TrimSpace(requested)))
+	allowed := allowedDocumentTypes(role)
+	if normalized != "" && allowed[normalized] {
+		return normalized
+	}
+	return portalDocumentTypeNote
+}
+
+func clampDocumentTitle(title string) string {
+	cleaned := strings.TrimSpace(title)
+	if cleaned == "" {
+		cleaned = "Untitled note"
+	}
+	if utf8.RuneCountInString(cleaned) <= portalDocumentMaxTitle {
+		return cleaned
+	}
+	runes := []rune(cleaned)
+	return string(runes[:portalDocumentMaxTitle])
+}
+
+func formatDocumentSize(bytes int) string {
+	if bytes%1024 == 0 {
+		return fmt.Sprintf("%d KB", bytes/1024)
+	}
+	return fmt.Sprintf("%d bytes", bytes)
+}
+
 func randomToken(length int) (string, error) {
 	buf := make([]byte, length)
 	if _, err := rand.Read(buf); err != nil {
@@ -513,11 +827,24 @@ func randomToken(length int) (string, error) {
 
 func isSupportedPortalRole(role PortalRole) bool {
 	switch role {
+	case PortalRoleBuilder, PortalRoleModerator, PortalRoleAdmin, PortalRolePlayer:
+		return true
+	default:
+		return false
+	}
+}
+
+func isStaffPortalRole(role PortalRole) bool {
+	switch role {
 	case PortalRoleBuilder, PortalRoleModerator, PortalRoleAdmin:
 		return true
 	default:
 		return false
 	}
+}
+
+func roleAllowsScripts(role PortalRole) bool {
+	return isStaffPortalRole(role)
 }
 
 type portalPlayerView struct {
@@ -534,17 +861,42 @@ type portalPlayerView struct {
 	SessionSeconds int64    `json:"session_seconds,omitempty"`
 }
 
+type portalDocument struct {
+	ID        string
+	Title     string
+	Content   string
+	Type      portalDocumentType
+	UpdatedAt time.Time
+	UpdatedBy string
+}
+
+type portalDocumentView struct {
+	ID        string `json:"id"`
+	Title     string `json:"title"`
+	Content   string `json:"content"`
+	Type      string `json:"type"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+	UpdatedBy string `json:"updated_by,omitempty"`
+}
+
 type portalPageData struct {
-	Player          string
-	Role            PortalRole
-	RoleTitle       string
-	RoleDescription string
-	Generated       string
-	SessionExpiry   string
-	Players         []portalPlayerView
-	PlayersJSON     template.JS
-	OverviewCounts  portalOverview
-	OverviewJSON    template.JS
+	Player           string
+	Role             PortalRole
+	RoleTitle        string
+	RoleDescription  string
+	Generated        string
+	SessionExpiry    string
+	Players          []portalPlayerView
+	PlayersJSON      template.JS
+	OverviewCounts   portalOverview
+	OverviewJSON     template.JS
+	Documents        []portalDocumentView
+	DocumentsJSON    template.JS
+	ShowStaffPanels  bool
+	AllowScripts     bool
+	DocumentLimit    int
+	DocumentMaxSize  int
+	DocumentMaxLabel string
 }
 
 type portalOverview struct {
@@ -600,6 +952,8 @@ func portalRoleTitle(role PortalRole) string {
 		return "LumenClay Administration"
 	case PortalRoleModerator:
 		return "LumenClay Moderation"
+	case PortalRolePlayer:
+		return "LumenClay Notes"
 	case PortalRoleBuilder:
 		fallthrough
 	default:
@@ -613,6 +967,8 @@ func portalRoleDescription(role PortalRole) string {
 		return "Review online activity, manage resets, and coordinate large-scale changes."
 	case PortalRoleModerator:
 		return "Monitor player activity, coordinate community efforts, and respond to incidents."
+	case PortalRolePlayer:
+		return "Capture notes, share collaborative descriptions, and plan adventures together."
 	case PortalRoleBuilder:
 		fallthrough
 	default:
@@ -653,6 +1009,36 @@ tr:last-child td { border-bottom: none; }
 .role-chip { display: inline-block; margin: 0 0.35rem 0.35rem 0; padding: 0.2rem 0.6rem; border-radius: 999px; background: rgba(148, 163, 184, 0.18); font-size: 0.75rem; }
 .vital-metric { font-variant-numeric: tabular-nums; }
 .session-pill { display: inline-block; padding: 0.2rem 0.65rem; border-radius: 999px; background: rgba(56, 189, 248, 0.18); color: #bae6fd; font-size: 0.75rem; letter-spacing: 0.04em; }
+.doc-layout { display: flex; gap: 1.5rem; margin-top: 1.25rem; flex-wrap: wrap; }
+.doc-list { flex: 0 0 260px; background: rgba(15, 23, 42, 0.7); border: 1px solid rgba(148, 163, 184, 0.15); border-radius: 0.9rem; padding: 0.85rem; box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.12); max-height: 420px; overflow-y: auto; }
+.doc-entry { width: 100%; text-align: left; background: transparent; border: 1px solid transparent; color: #e2e8f0; padding: 0.65rem 0.75rem; border-radius: 0.75rem; cursor: pointer; transition: background 0.2s ease, border-color 0.2s ease; display: flex; flex-direction: column; gap: 0.25rem; }
+.doc-entry strong { font-size: 0.95rem; font-weight: 600; }
+.doc-entry .doc-meta { font-size: 0.75rem; color: #94a3b8; }
+.doc-entry:hover { background: rgba(56, 189, 248, 0.12); border-color: rgba(56, 189, 248, 0.35); }
+.doc-entry.active { background: rgba(56, 189, 248, 0.18); border-color: rgba(56, 189, 248, 0.45); }
+.doc-editor { flex: 1 1 320px; display: flex; flex-direction: column; gap: 0.75rem; }
+.doc-label { font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.08em; color: #94a3b8; }
+.doc-editor input[type="text"], .doc-editor select { border-radius: 0.75rem; border: 1px solid rgba(148, 163, 184, 0.25); background: rgba(15, 23, 42, 0.75); color: #f8fafc; padding: 0.65rem 0.75rem; font-size: 1rem; }
+.doc-editor select { appearance: none; background-image: linear-gradient(45deg, transparent 50%, #38bdf8 50%), linear-gradient(135deg, #38bdf8 50%, transparent 50%); background-position: calc(100% - 18px) calc(1em + 2px), calc(100% - 13px) calc(1em + 2px); background-size: 5px 5px, 5px 5px; background-repeat: no-repeat; padding-right: 2.5rem; }
+.doc-editor textarea { border-radius: 0.75rem; border: 1px solid rgba(148, 163, 184, 0.25); background: rgba(15, 23, 42, 0.75); color: #f8fafc; padding: 0.75rem; min-height: 240px; resize: vertical; font-family: "Fira Code", "SFMono-Regular", Menlo, Consolas, monospace; font-size: 0.95rem; line-height: 1.5; }
+.doc-editor textarea:focus, .doc-editor input[type="text"]:focus, .doc-editor select:focus { outline: none; border-color: rgba(56, 189, 248, 0.5); box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.18); }
+.doc-note { font-size: 0.8rem; color: #94a3b8; margin: 0; }
+.doc-highlight-wrapper { display: flex; flex-direction: column; gap: 0.35rem; }
+.code-preview { border-radius: 0.75rem; border: 1px solid rgba(148, 163, 184, 0.25); background: rgba(6, 11, 27, 0.85); color: #e2e8f0; padding: 0.75rem; min-height: 200px; overflow: auto; font-family: "Fira Code", "SFMono-Regular", Menlo, Consolas, monospace; font-size: 0.95rem; line-height: 1.5; white-space: pre-wrap; }
+.hl-keyword { color: #93c5fd; }
+.hl-type { color: #facc15; }
+.hl-builtin { color: #2dd4bf; }
+.hl-comment { color: #64748b; font-style: italic; }
+.hl-string { color: #fca5a5; }
+.doc-entry .doc-meta-type { display: inline-block; text-transform: uppercase; letter-spacing: 0.08em; font-size: 0.7rem; color: #f9a8d4; }
+.doc-actions { display: flex; align-items: center; flex-wrap: wrap; gap: 0.75rem; }
+.doc-actions .doc-buttons { display: flex; gap: 0.6rem; }
+.doc-actions button { border: none; border-radius: 999px; padding: 0.5rem 1.1rem; font-size: 0.85rem; font-weight: 600; cursor: pointer; transition: transform 0.15s ease, box-shadow 0.15s ease; }
+.doc-actions button.primary { background: linear-gradient(120deg, #38bdf8, #3b82f6); color: #0f172a; box-shadow: 0 8px 20px rgba(56, 189, 248, 0.35); }
+.doc-actions button.primary:hover { transform: translateY(-1px); box-shadow: 0 10px 24px rgba(56, 189, 248, 0.45); }
+.doc-actions button.secondary { background: rgba(148, 163, 184, 0.2); color: #e2e8f0; }
+.doc-actions button.secondary:hover { background: rgba(148, 163, 184, 0.3); }
+.doc-status { font-size: 0.85rem; color: #94a3b8; min-height: 1.2rem; }
 footer { text-align: center; font-size: 0.8rem; color: #94a3b8; padding: 2rem 0 3rem; }
 @media (max-width: 720px) {
  header, main { padding-left: 6vw; padding-right: 6vw; }
@@ -661,6 +1047,8 @@ footer { text-align: center; font-size: 0.8rem; color: #94a3b8; padding: 2rem 0 
  td { border: none; padding: 0.5rem 0; }
  td::before { content: attr(data-label); font-weight: 600; display: block; color: #38bdf8; margin-bottom: 0.25rem; }
  .session-pill { display: inline-block; margin-top: 0.25rem; }
+ .doc-layout { flex-direction: column; }
+ .doc-list { max-height: none; }
 }
 </style>
 </head>
@@ -672,6 +1060,7 @@ footer { text-align: center; font-size: 0.8rem; color: #94a3b8; padding: 2rem 0 
 <p><small>Session active until {{.SessionExpiry}} · Refreshed {{.Generated}}</small></p>
 </header>
 <main>
+{{if .ShowStaffPanels}}
 <section>
 <h2>At a Glance</h2>
 <p>Confirm coverage and connection health at a glance.</p>
@@ -704,6 +1093,39 @@ footer { text-align: center; font-size: 0.8rem; color: #94a3b8; padding: 2rem 0 
 <div id="players-container"></div>
 <p class="table-note">Data updates every 10 seconds while this page stays open.</p>
 </section>
+{{end}}
+<section>
+<h2>Collaborative Notes</h2>
+<p>Draft descriptions, quest scripts, and planning notes together.</p>
+<div class="doc-layout">
+<div class="doc-list" id="doc-list"></div>
+<div class="doc-editor">
+{{if .AllowScripts}}
+<label class="doc-label" for="doc-type">Document type</label>
+<select id="doc-type">
+<option value="note">Note</option>
+<option value="script">Script</option>
+</select>
+{{end}}
+<label class="doc-label" for="doc-title">Title</label>
+<input id="doc-title" type="text" placeholder="Untitled note" autocomplete="off" />
+<label class="doc-label" for="doc-content">Content</label>
+<textarea id="doc-content" spellcheck="true" placeholder="Collect ideas, outline scripts, or paste builder text here."></textarea>
+<p class="doc-note">Keep up to {{.DocumentLimit}} documents. Each entry may contain at most {{.DocumentMaxLabel}} of text.</p>
+<div class="doc-highlight-wrapper" id="doc-highlight-container" hidden>
+<label class="doc-label" for="doc-highlight">Go preview</label>
+<pre id="doc-highlight" class="code-preview"></pre>
+</div>
+<div class="doc-actions">
+<div class="doc-buttons">
+<button type="button" class="secondary" id="doc-new">New document</button>
+<button type="button" class="primary" id="doc-save">Save changes</button>
+</div>
+<span class="doc-status" id="doc-status"></span>
+</div>
+</div>
+</div>
+</section>
 <section>
 <h2>Quick Tips</h2>
 <ul>
@@ -720,6 +1142,19 @@ footer { text-align: center; font-size: 0.8rem; color: #94a3b8; padding: 2rem 0 
 <script>
 const playersMount = document.getElementById('players-container');
 const overviewMount = document.getElementById('overview-container');
+const docList = document.getElementById('doc-list');
+const docTitleInput = document.getElementById('doc-title');
+const docContentInput = document.getElementById('doc-content');
+const docStatus = document.getElementById('doc-status');
+const docSaveButton = document.getElementById('doc-save');
+const docNewButton = document.getElementById('doc-new');
+const docTypeSelect = document.getElementById('doc-type');
+const docHighlightContainer = document.getElementById('doc-highlight-container');
+const docHighlight = document.getElementById('doc-highlight');
+const allowScripts = {{if .AllowScripts}}true{{else}}false{{end}};
+const docLimit = {{.DocumentLimit}};
+const docMaxBytes = {{.DocumentMaxSize}};
+const textEncoder = typeof TextEncoder !== 'undefined' ? new TextEncoder() : null;
 const htmlEscapeMap = { '&': '&amp;', '<': '&lt;', '>': '&gt;' };
 htmlEscapeMap['"'] = '&quot;';
 htmlEscapeMap['\''] = '&#39;';
@@ -756,6 +1191,166 @@ const formatSession = (seconds) => {
     parts.push(Math.round(total) + 's');
   }
   return parts.join(' ');
+};
+const formatTimestamp = (value) => {
+  if (!value) {
+    return '';
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return String(value);
+  }
+  return parsed.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+const byteLength = (value) => {
+  if (value == null) {
+    return 0;
+  }
+  if (textEncoder) {
+    try {
+      return textEncoder.encode(String(value)).length;
+    } catch (err) {
+      // Fallback to string length if encoding fails
+    }
+  }
+  return String(value).length;
+};
+const docTypeLabel = (value) => (value === 'script' ? 'Script' : 'Note');
+const sanitizeDocType = (value) => (allowScripts && value === 'script' ? 'script' : 'note');
+const goKeywords = new Set(['break','case','chan','const','continue','default','defer','else','fallthrough','for','func','go','goto','if','import','interface','map','package','range','return','select','struct','switch','type','var']);
+const goTypes = new Set(['bool','byte','complex128','complex64','error','float32','float64','int','int16','int32','int64','int8','rune','string','uint','uint16','uint32','uint64','uint8','uintptr']);
+const goBuiltins = new Set(['append','cap','close','complex','copy','delete','imag','len','make','new','panic','print','println','real','recover']);
+const goBacktick = String.fromCharCode(96);
+const highlightGo = (source) => {
+  if (!source) {
+    return '';
+  }
+  const segments = [];
+  const text = String(source);
+  const length = text.length;
+  let index = 0;
+  const push = (type, value) => {
+    if (value === '') {
+      return;
+    }
+    const escaped = escapeHTML(value);
+    switch (type) {
+      case 'keyword':
+        segments.push('<span class="hl-keyword">' + escaped + '</span>');
+        break;
+      case 'type':
+        segments.push('<span class="hl-type">' + escaped + '</span>');
+        break;
+      case 'builtin':
+        segments.push('<span class="hl-builtin">' + escaped + '</span>');
+        break;
+      case 'comment':
+        segments.push('<span class="hl-comment">' + escaped + '</span>');
+        break;
+      case 'string':
+        segments.push('<span class="hl-string">' + escaped + '</span>');
+        break;
+      default:
+        segments.push(escaped);
+    }
+  };
+  while (index < length) {
+    const char = text[index];
+    const next = text[index + 1];
+    if (char === '/' && next === '/') {
+      let end = text.indexOf('\n', index + 2);
+      if (end === -1) {
+        end = length;
+      }
+      push('comment', text.slice(index, end));
+      index = end;
+      continue;
+    }
+    if (char === '/' && next === '*') {
+      let end = text.indexOf('*/', index + 2);
+      if (end === -1) {
+        end = length;
+      } else {
+        end += 2;
+      }
+      push('comment', text.slice(index, end));
+      index = end;
+      continue;
+    }
+    if (char === '"' || char === '\'' || char === goBacktick) {
+      const quote = char;
+      let end = index + 1;
+      if (quote === goBacktick) {
+        const closing = text.indexOf(goBacktick, end);
+        end = closing === -1 ? length : closing + 1;
+      } else {
+        while (end < length) {
+          const current = text[end];
+          if (current === '\\') {
+            end += 2;
+            continue;
+          }
+          if (current === quote) {
+            end++;
+            break;
+          }
+          end++;
+        }
+        if (end > length) {
+          end = length;
+        }
+      }
+      push('string', text.slice(index, end));
+      index = end;
+      continue;
+    }
+    if ((char >= 'A' && char <= 'Z') || (char >= 'a' && char <= 'z') || char === '_') {
+      let end = index + 1;
+      while (end < length) {
+        const current = text[end];
+        if ((current >= 'A' && current <= 'Z') || (current >= 'a' && current <= 'z') || (current >= '0' && current <= '9') || current === '_') {
+          end++;
+          continue;
+        }
+        break;
+      }
+      const word = text.slice(index, end);
+      if (goKeywords.has(word)) {
+        push('keyword', word);
+      } else if (goTypes.has(word)) {
+        push('type', word);
+      } else if (goBuiltins.has(word)) {
+        push('builtin', word);
+      } else {
+        push('text', word);
+      }
+      index = end;
+      continue;
+    }
+    push('text', char);
+    index++;
+  }
+  return segments.join('');
+};
+const syncHighlight = () => {
+  if (!docHighlight || !docHighlightContainer) {
+    return;
+  }
+  const activeType = docTypeSelect ? sanitizeDocType(docTypeSelect.value) : 'note';
+  if (activeType === 'script') {
+    docHighlightContainer.hidden = false;
+    const content = docContentInput ? docContentInput.value : '';
+    docHighlight.innerHTML = highlightGo(content);
+  } else {
+    docHighlightContainer.hidden = true;
+    docHighlight.innerHTML = '';
+  }
 };
 const renderPlayers = (entries) => {
   if (!entries || !entries.length) {
@@ -796,10 +1391,224 @@ const renderOverview = (summary) => {
   ];
   overviewMount.innerHTML = cards.map((card) => '<div class="stat-card"><div class="stat-label">' + card.label + '</div><div class="stat-value">' + escapeHTML(card.value) + '</div><div class="stat-subtext">' + escapeHTML(card.subtext) + '</div></div>').join('');
 };
+const initialDocuments = {{.DocumentsJSON}};
+let documents = Array.isArray(initialDocuments) ? initialDocuments.slice(0, docLimit) : [];
+documents = documents.filter((entry) => entry && entry.id).map((entry) => ({
+  ...entry,
+  type: sanitizeDocType(entry.type),
+}));
+let activeDocumentId = documents.length ? documents[0]?.id || null : null;
+const getActiveDocument = () => documents.find((doc) => doc && doc.id === activeDocumentId) || null;
+const updateDocumentsCollection = (entry) => {
+  if (!entry || !entry.id) {
+    return;
+  }
+  const normalized = { ...entry, type: sanitizeDocType(entry.type) };
+  documents = documents.filter((doc) => doc && doc.id !== normalized.id);
+  documents.unshift(normalized);
+  if (documents.length > docLimit) {
+    documents = documents.slice(0, docLimit);
+  }
+};
+const renderDocumentList = () => {
+  if (!docList) {
+    return;
+  }
+  if (!documents.length) {
+    docList.innerHTML = '<p class="empty-state">No saved documents yet. Use “New document” to begin.</p>';
+    return;
+  }
+  const parts = [];
+  for (const entry of documents) {
+    if (!entry || !entry.id) {
+      continue;
+    }
+    const isActive = entry.id === activeDocumentId;
+    const classes = 'doc-entry' + (isActive ? ' active' : '');
+    const metaParts = [];
+    const typeLabel = docTypeLabel(entry.type);
+    const typeBadge = typeLabel ? ' <span class="doc-meta-type">' + escapeHTML(typeLabel) + '</span>' : '';
+    if (entry.updated_at) {
+      metaParts.push(formatTimestamp(entry.updated_at));
+    }
+    if (entry.updated_by) {
+      metaParts.push('by ' + entry.updated_by);
+    }
+    const metaText = metaParts.map((part) => escapeHTML(part)).join(' · ');
+    const meta = metaText ? '<span class="doc-meta">' + metaText + '</span>' : '';
+    parts.push('<button type="button" class="' + classes + '" data-doc-id="' + escapeHTML(entry.id) + '"><strong>' + escapeHTML(entry.title || 'Untitled note') + '</strong>' + typeBadge + (meta ? ' ' + meta : '') + '</button>');
+  }
+  docList.innerHTML = parts.join('');
+};
+const setDocumentStatus = (entry) => {
+  if (!docStatus) {
+    return;
+  }
+  if (!entry || !entry.id) {
+    const activeType = docTypeLabel(docTypeSelect ? sanitizeDocType(docTypeSelect.value) : 'note');
+    docStatus.textContent = activeType + ' draft — keep under ' + docMaxBytes + ' bytes.';
+    return;
+  }
+  const pieces = [];
+  const typeLabel = docTypeLabel(entry.type);
+  if (typeLabel) {
+    pieces.push(typeLabel);
+  }
+  const size = byteLength(entry.content);
+  if (size) {
+    pieces.push(size + ' bytes');
+  }
+  if (entry.updated_at) {
+    pieces.push('Saved ' + formatTimestamp(entry.updated_at));
+  }
+  if (entry.updated_by) {
+    pieces.push('by ' + entry.updated_by);
+  }
+  docStatus.textContent = pieces.length ? pieces.join(' ') : 'Saved';
+};
+const focusDocument = (entry) => {
+  if (!docTitleInput || !docContentInput) {
+    return;
+  }
+  activeDocumentId = entry && entry.id ? entry.id : null;
+  const docTypeValue = entry && entry.type ? sanitizeDocType(entry.type) : 'note';
+  if (docTypeSelect) {
+    docTypeSelect.value = docTypeValue;
+  }
+  docTitleInput.value = entry && entry.title ? entry.title : '';
+  docContentInput.value = entry && typeof entry.content === 'string' ? entry.content : '';
+  setDocumentStatus(entry);
+  syncHighlight();
+  renderDocumentList();
+};
+const selectDocument = async (id) => {
+  if (!id) {
+    return;
+  }
+  const existing = documents.find((doc) => doc && doc.id === id);
+  if (existing && typeof existing.content === 'string') {
+    focusDocument(existing);
+    return;
+  }
+  try {
+    const response = await fetch('/api/documents?id=' + encodeURIComponent(id), { credentials: 'same-origin' });
+    if (!response.ok) {
+      throw new Error('Document fetch failed');
+    }
+    const doc = await response.json();
+    updateDocumentsCollection(doc);
+    focusDocument(doc);
+  } catch (err) {
+    console.warn('Document fetch failed', err);
+  }
+};
 const initialPlayers = {{.PlayersJSON}};
 renderPlayers(initialPlayers);
 const initialOverview = {{.OverviewJSON}};
 renderOverview(initialOverview);
+renderDocumentList();
+if (documents.length) {
+  focusDocument(documents[0]);
+} else if (docStatus) {
+  docStatus.textContent = 'Start a new document to capture ideas (limit ' + docMaxBytes + ' bytes).';
+}
+syncHighlight();
+if (docList) {
+  docList.addEventListener('click', (event) => {
+    const button = event.target.closest('button[data-doc-id]');
+    if (!button) {
+      return;
+    }
+    selectDocument(button.getAttribute('data-doc-id'));
+  });
+}
+if (docContentInput) {
+  docContentInput.addEventListener('input', () => {
+    const size = byteLength(docContentInput.value);
+    const typeLabel = docTypeLabel(docTypeSelect ? sanitizeDocType(docTypeSelect.value) : 'note');
+    if (docStatus) {
+      docStatus.textContent = (typeLabel ? typeLabel + ' ' : '') + 'draft — ' + size + ' bytes (limit ' + docMaxBytes + ')';
+    }
+    syncHighlight();
+  });
+}
+if (docTypeSelect) {
+  docTypeSelect.addEventListener('change', () => {
+    const normalized = sanitizeDocType(docTypeSelect.value);
+    const active = getActiveDocument();
+    if (active) {
+      active.type = normalized;
+    }
+    setDocumentStatus(active || null);
+    renderDocumentList();
+    syncHighlight();
+  });
+}
+if (docNewButton) {
+  docNewButton.addEventListener('click', () => {
+    activeDocumentId = null;
+    if (docTitleInput) {
+      docTitleInput.value = '';
+      docTitleInput.focus();
+    }
+    if (docContentInput) {
+      docContentInput.value = '';
+    }
+    if (docTypeSelect) {
+      docTypeSelect.value = 'note';
+    }
+    setDocumentStatus(null);
+    syncHighlight();
+    renderDocumentList();
+  });
+}
+if (docSaveButton) {
+  docSaveButton.addEventListener('click', async () => {
+    if (!docTitleInput || !docContentInput) {
+      return;
+    }
+    const payloadType = docTypeSelect ? sanitizeDocType(docTypeSelect.value) : 'note';
+    const currentSize = byteLength(docContentInput.value);
+    if (currentSize > docMaxBytes) {
+      if (docStatus) {
+        docStatus.textContent = 'Too large to save (' + currentSize + ' bytes, limit ' + docMaxBytes + ').';
+      }
+      return;
+    }
+    if (docStatus) {
+      docStatus.textContent = 'Saving…';
+    }
+    try {
+      const response = await fetch('/api/documents', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({
+          id: activeDocumentId,
+          title: docTitleInput.value,
+          content: docContentInput.value,
+          type: payloadType,
+        }),
+      });
+      if (!response.ok) {
+        const text = (await response.text()).trim();
+        throw new Error(text || 'Save failed');
+      }
+      const saved = await response.json();
+      updateDocumentsCollection(saved);
+      focusDocument(saved);
+      if (docStatus) {
+        const label = docTypeLabel(saved.type);
+        docStatus.textContent = (label ? label + ' ' : '') + 'saved just now';
+      }
+    } catch (err) {
+      console.warn('Document save failed', err);
+      if (docStatus) {
+        docStatus.textContent = err && err.message ? err.message : 'Save failed — retry?';
+      }
+    }
+  });
+}
 const refresh = async () => {
   try {
     const [playersResult, overviewResult] = await Promise.allSettled([

--- a/internal/game/portal_test.go
+++ b/internal/game/portal_test.go
@@ -1,8 +1,11 @@
 package game
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -102,6 +105,497 @@ func TestPortalLinkSingleUse(t *testing.T) {
 		t.Fatalf("token reuse status = %d, want %d", resp3.StatusCode, http.StatusNotFound)
 	}
 	resp3.Body.Close()
+}
+
+func TestPortalDocumentsAPI(t *testing.T) {
+	dir := t.TempDir()
+	cert := filepath.Join(dir, "portal-cert.pem")
+	key := filepath.Join(dir, "portal-key.pem")
+	world := NewWorldWithRooms(map[RoomID]*Room{
+		"start": {ID: "start", Title: "Atrium", Description: "", Exits: map[string]RoomID{}},
+	})
+	player := &Player{Name: "Builder", Room: "start", Alive: true, Output: make(chan string, 1)}
+	player.IsBuilder = true
+	world.AddPlayerForTest(player)
+
+	cfg := PortalConfig{Addr: "127.0.0.1:0", CertFile: cert, KeyFile: key}
+	provider, err := newPortalServer(world, cfg)
+	if err != nil {
+		t.Fatalf("newPortalServer error: %v", err)
+	}
+	portal := provider.(*PortalServer)
+	t.Cleanup(func() {
+		_ = portal.Close()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := portal.WaitReady(ctx); err != nil {
+		t.Fatalf("portal did not start: %v", err)
+	}
+
+	link, err := provider.GenerateLink(PortalRoleBuilder, "Builder")
+	if err != nil {
+		t.Fatalf("GenerateLink error: %v", err)
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	resp, err := client.Get(link.URL)
+	if err != nil {
+		t.Fatalf("GET portal token failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("token exchange status = %d, want %d", resp.StatusCode, http.StatusSeeOther)
+	}
+	cookie := findPortalCookie(resp.Cookies())
+	if cookie == nil {
+		t.Fatalf("portal cookie not set on initial response")
+	}
+	resp.Body.Close()
+
+	baseURL, err := url.Parse(portal.BaseURL())
+	if err != nil {
+		t.Fatalf("parse base url: %v", err)
+	}
+
+	docURL := baseURL.JoinPath("api", "documents")
+	saveReq, err := http.NewRequest(http.MethodPost, docURL.String(), strings.NewReader(`{"title":"Observatory Sketch","content":"Stars align"}`))
+	if err != nil {
+		t.Fatalf("create save request: %v", err)
+	}
+	saveReq.Header.Set("Content-Type", "application/json")
+	saveReq.AddCookie(cookie)
+	saveResp, err := client.Do(saveReq)
+	if err != nil {
+		t.Fatalf("POST documents failed: %v", err)
+	}
+	if saveResp.StatusCode != http.StatusOK {
+		t.Fatalf("save status = %d, want %d", saveResp.StatusCode, http.StatusOK)
+	}
+	var created struct {
+		ID        string `json:"id"`
+		Title     string `json:"title"`
+		Content   string `json:"content"`
+		Type      string `json:"type"`
+		UpdatedAt string `json:"updated_at"`
+		UpdatedBy string `json:"updated_by"`
+	}
+	if err := json.NewDecoder(saveResp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode save response: %v", err)
+	}
+	saveResp.Body.Close()
+	if created.ID == "" {
+		t.Fatalf("expected document id in response")
+	}
+	if created.Title != "Observatory Sketch" {
+		t.Fatalf("title mismatch: %q", created.Title)
+	}
+	if created.Content != "Stars align" {
+		t.Fatalf("content mismatch: %q", created.Content)
+	}
+	if created.UpdatedBy != "Builder" {
+		t.Fatalf("updated_by mismatch: %q", created.UpdatedBy)
+	}
+	if created.UpdatedAt == "" {
+		t.Fatalf("expected updated_at timestamp")
+	}
+	if created.Type != "note" {
+		t.Fatalf("expected default type note, got %q", created.Type)
+	}
+
+	listReq, err := http.NewRequest(http.MethodGet, docURL.String(), nil)
+	if err != nil {
+		t.Fatalf("create list request: %v", err)
+	}
+	listReq.AddCookie(cookie)
+	listResp, err := client.Do(listReq)
+	if err != nil {
+		t.Fatalf("GET documents failed: %v", err)
+	}
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("list status = %d, want %d", listResp.StatusCode, http.StatusOK)
+	}
+	var docs []struct {
+		ID      string `json:"id"`
+		Title   string `json:"title"`
+		Content string `json:"content"`
+		Type    string `json:"type"`
+	}
+	if err := json.NewDecoder(listResp.Body).Decode(&docs); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	listResp.Body.Close()
+	if len(docs) == 0 {
+		t.Fatalf("expected at least one document in list")
+	}
+	if docs[0].ID != created.ID {
+		t.Fatalf("first doc id = %q, want %q", docs[0].ID, created.ID)
+	}
+	if docs[0].Content != "Stars align" {
+		t.Fatalf("first doc content mismatch: %q", docs[0].Content)
+	}
+	if docs[0].Type != "note" {
+		t.Fatalf("first doc type mismatch: %q", docs[0].Type)
+	}
+}
+
+func TestPortalScriptFormatting(t *testing.T) {
+	dir := t.TempDir()
+	cert := filepath.Join(dir, "portal-cert.pem")
+	key := filepath.Join(dir, "portal-key.pem")
+	world := NewWorldWithRooms(map[RoomID]*Room{
+		"start": {ID: "start", Title: "Atrium", Description: "", Exits: map[string]RoomID{}},
+	})
+	builder := &Player{Name: "Builder", Room: "start", Alive: true, Output: make(chan string, 1)}
+	builder.IsBuilder = true
+	world.AddPlayerForTest(builder)
+
+	cfg := PortalConfig{Addr: "127.0.0.1:0", CertFile: cert, KeyFile: key}
+	provider, err := newPortalServer(world, cfg)
+	if err != nil {
+		t.Fatalf("newPortalServer error: %v", err)
+	}
+	portal := provider.(*PortalServer)
+	t.Cleanup(func() {
+		_ = portal.Close()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := portal.WaitReady(ctx); err != nil {
+		t.Fatalf("portal did not start: %v", err)
+	}
+
+	link, err := provider.GenerateLink(PortalRoleBuilder, "Builder")
+	if err != nil {
+		t.Fatalf("GenerateLink error: %v", err)
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	resp, err := client.Get(link.URL)
+	if err != nil {
+		t.Fatalf("GET portal token failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("token exchange status = %d, want %d", resp.StatusCode, http.StatusSeeOther)
+	}
+	cookie := findPortalCookie(resp.Cookies())
+	if cookie == nil {
+		t.Fatalf("portal cookie not set on initial response")
+	}
+	resp.Body.Close()
+
+	baseURL, err := url.Parse(portal.BaseURL())
+	if err != nil {
+		t.Fatalf("parse base url: %v", err)
+	}
+
+	docURL := baseURL.JoinPath("api", "documents")
+	scriptPayload := map[string]string{
+		"title":   "Automation",
+		"content": "package main\nfunc main(){println(\"ok\")}",
+		"type":    "script",
+	}
+	scriptBody, err := json.Marshal(scriptPayload)
+	if err != nil {
+		t.Fatalf("marshal script payload: %v", err)
+	}
+	scriptReq, err := http.NewRequest(http.MethodPost, docURL.String(), bytes.NewReader(scriptBody))
+	if err != nil {
+		t.Fatalf("create script request: %v", err)
+	}
+	scriptReq.Header.Set("Content-Type", "application/json")
+	scriptReq.AddCookie(cookie)
+	scriptResp, err := client.Do(scriptReq)
+	if err != nil {
+		t.Fatalf("POST script document failed: %v", err)
+	}
+	if scriptResp.StatusCode != http.StatusOK {
+		t.Fatalf("script save status = %d, want %d", scriptResp.StatusCode, http.StatusOK)
+	}
+	var formatted struct {
+		ID      string `json:"id"`
+		Title   string `json:"title"`
+		Content string `json:"content"`
+		Type    string `json:"type"`
+	}
+	if err := json.NewDecoder(scriptResp.Body).Decode(&formatted); err != nil {
+		t.Fatalf("decode script response: %v", err)
+	}
+	scriptResp.Body.Close()
+	if formatted.Type != "script" {
+		t.Fatalf("formatted type = %q, want script", formatted.Type)
+	}
+	expected := "package main\n\nfunc main() { println(\"ok\") }\n"
+	if formatted.Content != expected {
+		t.Fatalf("formatted content mismatch:\nwant %q\n got %q", expected, formatted.Content)
+	}
+
+	badPayload := map[string]string{
+		"title":   "Broken",
+		"content": "package main\nfunc main(",
+		"type":    "script",
+	}
+	badBody, err := json.Marshal(badPayload)
+	if err != nil {
+		t.Fatalf("marshal invalid payload: %v", err)
+	}
+	badReq, err := http.NewRequest(http.MethodPost, docURL.String(), bytes.NewReader(badBody))
+	if err != nil {
+		t.Fatalf("create invalid script request: %v", err)
+	}
+	badReq.Header.Set("Content-Type", "application/json")
+	badReq.AddCookie(cookie)
+	badResp, err := client.Do(badReq)
+	if err != nil {
+		t.Fatalf("POST invalid script failed: %v", err)
+	}
+	if badResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("invalid script status = %d, want %d", badResp.StatusCode, http.StatusBadRequest)
+	}
+	bodyBytes, _ := io.ReadAll(badResp.Body)
+	badResp.Body.Close()
+	if !strings.Contains(string(bodyBytes), "script validation failed") {
+		t.Fatalf("expected validation failure message, got %q", string(bodyBytes))
+	}
+}
+
+func TestPortalPlayerAccessNotesOnly(t *testing.T) {
+	dir := t.TempDir()
+	cert := filepath.Join(dir, "portal-cert.pem")
+	key := filepath.Join(dir, "portal-key.pem")
+	world := NewWorldWithRooms(map[RoomID]*Room{
+		"start": {ID: "start", Title: "Atrium", Description: "", Exits: map[string]RoomID{}},
+	})
+	builder := &Player{Name: "Builder", Room: "start", Alive: true, Output: make(chan string, 1)}
+	builder.IsBuilder = true
+	world.AddPlayerForTest(builder)
+	player := &Player{Name: "Seeker", Room: "start", Alive: true, Output: make(chan string, 1)}
+	world.AddPlayerForTest(player)
+
+	cfg := PortalConfig{Addr: "127.0.0.1:0", CertFile: cert, KeyFile: key}
+	provider, err := newPortalServer(world, cfg)
+	if err != nil {
+		t.Fatalf("newPortalServer error: %v", err)
+	}
+	portal := provider.(*PortalServer)
+	t.Cleanup(func() {
+		_ = portal.Close()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := portal.WaitReady(ctx); err != nil {
+		t.Fatalf("portal did not start: %v", err)
+	}
+
+	builderSession := portalSession{Role: PortalRoleBuilder, Player: "Builder"}
+	_, err = portal.saveDocument(builderSession, "", "Shared note", "Gathering tonight at 9 bells.", "note")
+	if err != nil {
+		t.Fatalf("seed note: %v", err)
+	}
+	scriptView, err := portal.saveDocument(builderSession, "", "Secret script", "package main\nfunc main() { println(\"hi\") }", "script")
+	if err != nil {
+		t.Fatalf("seed script: %v", err)
+	}
+
+	link, err := provider.GenerateLink(PortalRolePlayer, "Seeker")
+	if err != nil {
+		t.Fatalf("GenerateLink error: %v", err)
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	resp, err := client.Get(link.URL)
+	if err != nil {
+		t.Fatalf("GET portal token failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("token exchange status = %d, want %d", resp.StatusCode, http.StatusSeeOther)
+	}
+	cookie := findPortalCookie(resp.Cookies())
+	if cookie == nil {
+		t.Fatalf("portal cookie not set on initial response")
+	}
+	resp.Body.Close()
+
+	baseURL, err := url.Parse(portal.BaseURL())
+	if err != nil {
+		t.Fatalf("parse base url: %v", err)
+	}
+
+	interfaceURL := baseURL.JoinPath("interface")
+	req, err := http.NewRequest(http.MethodGet, interfaceURL.String(), nil)
+	if err != nil {
+		t.Fatalf("create interface request: %v", err)
+	}
+	req.AddCookie(cookie)
+	interfaceResp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("GET interface failed: %v", err)
+	}
+	if interfaceResp.StatusCode != http.StatusOK {
+		t.Fatalf("interface status = %d, want %d", interfaceResp.StatusCode, http.StatusOK)
+	}
+	bodyBytes, err := io.ReadAll(interfaceResp.Body)
+	interfaceResp.Body.Close()
+	if err != nil {
+		t.Fatalf("read interface body: %v", err)
+	}
+	body := string(bodyBytes)
+	if strings.Contains(body, "<h2>At a Glance</h2>") {
+		t.Fatalf("player portal should not include staff overview")
+	}
+
+	docURL := baseURL.JoinPath("api", "documents")
+	listReq, err := http.NewRequest(http.MethodGet, docURL.String(), nil)
+	if err != nil {
+		t.Fatalf("create list request: %v", err)
+	}
+	listReq.AddCookie(cookie)
+	listResp, err := client.Do(listReq)
+	if err != nil {
+		t.Fatalf("GET documents failed: %v", err)
+	}
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("list status = %d, want %d", listResp.StatusCode, http.StatusOK)
+	}
+	var playerDocs []struct {
+		ID    string `json:"id"`
+		Title string `json:"title"`
+		Type  string `json:"type"`
+	}
+	if err := json.NewDecoder(listResp.Body).Decode(&playerDocs); err != nil {
+		t.Fatalf("decode player list: %v", err)
+	}
+	listResp.Body.Close()
+	if len(playerDocs) != 1 {
+		t.Fatalf("player docs len = %d, want 1", len(playerDocs))
+	}
+	if playerDocs[0].Type != "note" {
+		t.Fatalf("player doc type = %q, want note", playerDocs[0].Type)
+	}
+
+	docReq, err := http.NewRequest(http.MethodGet, docURL.String()+"?id="+url.QueryEscape(scriptView.ID), nil)
+	if err != nil {
+		t.Fatalf("create script fetch request: %v", err)
+	}
+	docReq.AddCookie(cookie)
+	docResp, err := client.Do(docReq)
+	if err != nil {
+		t.Fatalf("GET script document failed: %v", err)
+	}
+	if docResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("script fetch status = %d, want %d", docResp.StatusCode, http.StatusNotFound)
+	}
+	docResp.Body.Close()
+
+	playerPayload := map[string]string{
+		"title":   "Player attempt",
+		"content": "package main",
+		"type":    "script",
+	}
+	playerBody, err := json.Marshal(playerPayload)
+	if err != nil {
+		t.Fatalf("marshal player payload: %v", err)
+	}
+	saveReq, err := http.NewRequest(http.MethodPost, docURL.String(), bytes.NewReader(playerBody))
+	if err != nil {
+		t.Fatalf("create player save request: %v", err)
+	}
+	saveReq.Header.Set("Content-Type", "application/json")
+	saveReq.AddCookie(cookie)
+	saveResp, err := client.Do(saveReq)
+	if err != nil {
+		t.Fatalf("player POST failed: %v", err)
+	}
+	if saveResp.StatusCode != http.StatusOK {
+		t.Fatalf("player save status = %d, want %d", saveResp.StatusCode, http.StatusOK)
+	}
+	var playerCreated struct {
+		Type    string `json:"type"`
+		Content string `json:"content"`
+	}
+	if err := json.NewDecoder(saveResp.Body).Decode(&playerCreated); err != nil {
+		t.Fatalf("decode player save: %v", err)
+	}
+	saveResp.Body.Close()
+	if playerCreated.Type != "note" {
+		t.Fatalf("player-created doc type = %q, want note", playerCreated.Type)
+	}
+	if playerCreated.Content != "package main" {
+		t.Fatalf("player content mutated unexpectedly: %q", playerCreated.Content)
+	}
+}
+
+func TestPortalDocumentLimit(t *testing.T) {
+	dir := t.TempDir()
+	cert := filepath.Join(dir, "portal-cert.pem")
+	key := filepath.Join(dir, "portal-key.pem")
+	world := NewWorldWithRooms(map[RoomID]*Room{
+		"start": {ID: "start", Title: "Atrium", Description: "", Exits: map[string]RoomID{}},
+	})
+	builder := &Player{Name: "Builder", Room: "start", Alive: true, Output: make(chan string, 1)}
+	builder.IsBuilder = true
+	world.AddPlayerForTest(builder)
+
+	cfg := PortalConfig{Addr: "127.0.0.1:0", CertFile: cert, KeyFile: key}
+	provider, err := newPortalServer(world, cfg)
+	if err != nil {
+		t.Fatalf("newPortalServer error: %v", err)
+	}
+	portal := provider.(*PortalServer)
+	t.Cleanup(func() {
+		_ = portal.Close()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := portal.WaitReady(ctx); err != nil {
+		t.Fatalf("portal did not start: %v", err)
+	}
+
+	session := portalSession{Role: PortalRoleBuilder, Player: "Builder"}
+	total := portalDocumentLimit + 2
+	var lastID string
+	for i := 0; i < total; i++ {
+		title := fmt.Sprintf("Doc %02d", i)
+		content := fmt.Sprintf("body-%d", i)
+		view, err := portal.saveDocument(session, "", title, content, "note")
+		if err != nil {
+			t.Fatalf("save document %d: %v", i, err)
+		}
+		lastID = view.ID
+	}
+	docs := portal.documentSnapshotsForRole(PortalRoleBuilder)
+	if len(docs) != portalDocumentLimit {
+		t.Fatalf("doc count = %d, want %d", len(docs), portalDocumentLimit)
+	}
+	for _, doc := range docs {
+		if doc.Title == "Doc 00" {
+			t.Fatalf("oldest document should have been trimmed")
+		}
+	}
+	if docs[0].ID != lastID {
+		t.Fatalf("most recent document mismatch: %q vs %q", docs[0].ID, lastID)
+	}
 }
 
 func findPortalCookie(cookies []*http.Cookie) *http.Cookie {


### PR DESCRIPTION
## Summary
- open the portal notes backend to general players while enforcing document count/size limits and gofmt validation for staff scripts
- refresh the portal UI with document type controls, syntax-highlighted previews, and richer status messaging
- update the portal command/docs and add tests covering player notes access, script formatting, and document limits

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68da141325a8832aa4903daf03e6921f